### PR TITLE
adding new pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,8 @@ Quickbytes are tutorials designed to help CARC users.
          * [JupyterHub: Parallel Processing with MPI](https://github.com/UNM-CARC/QuickBytes/blob/master/parallelization_with%20Jupyterhub_using_mpi.md)
          * [Parallelization with JupyterHub using Dask and SciKit-learn](https://github.com/UNM-CARC/QuickBytes/blob/master/parallel_jupyterhub_with_dask_and_scikit-learn.md)
       * Anaconda
-         * [Intro to Anaconda]()
+         * [General intro to Anaconda](https://github.com/UNM-CARC/QuickBytes/blob/master/anaconda_general_intro.md)
+         * [Intro to Anaconda with example](https://github.com/UNM-CARC/QuickBytes/blob/master/anaconda_intro.md)
          * [Anaconda pip channels](https://github.com/UNM-CARC/QuickBytes/blob/master/anaconda_pip_channels.md)
       * R
          * [R Programming in HPC](https://github.com/UNM-CARC/QuickBytes/blob/master/R_usage.md)
@@ -38,8 +39,8 @@ Quickbytes are tutorials designed to help CARC users.
       * [Docker and Singularity](https://github.com/UNM-CARC/QuickBytes/blob/master/singularity-markdown-version.md)
       * [Haskell at CARC](https://github.com/UNM-CARC/QuickBytes/blob/master/haskell.md)
       * [BEAST at CARC](https://github.com/UNM-CARC/QuickBytes/blob/master/Beast_at_CARC.md)
-      * [X11 Forwarding]()
-      * [Spark]()
+      * [X11 Forwarding](https://github.com/UNM-CARC/QuickBytes/blob/master/X11_forwarding.md)
+      * [Spark](https://github.com/UNM-CARC/QuickBytes/blob/master/spark.md)
      
   
       

--- a/README.md
+++ b/README.md
@@ -2,9 +2,7 @@
 Quickbytes are tutorials designed to help CARC users.  
 
    * [Linux-Intro](https://github.com/UNM-CARC/QuickBytes/blob/master/linux_intro.md)
-   
-   * [Research Usage Policy](https://github.com/UNM-CARC/QuickBytes/blob/master/Resource_usage.md)
-   
+
    * Running jobs
       * [Logging in](https://github.com/UNM-CARC/QuickBytes/blob/master/logging_in.md)
       * [Transerring data](https://github.com/UNM-CARC/QuickBytes/blob/master/transfer_data.md)

--- a/README.md
+++ b/README.md
@@ -1,15 +1,20 @@
 # QuickBytes
-This table of contents will contain links to all the quickbytes, providing a singe page that the main CARC website can link to as well as making the github quickbytes stand on their own.
+Quickbytes are tutorials designed to help CARC users.  
 
    * [Linux-Intro](https://github.com/UNM-CARC/QuickBytes/blob/master/linux_intro.md)
    
    * [Research Usage Policy](https://github.com/UNM-CARC/QuickBytes/blob/master/Resource_usage.md)
    
    * Running jobs
-      * [Check Running jobs](https://github.com/UNM-CARC/QuickBytes/blob/master/checking_on_running_jobs.md) 
+      * [Logging in](https://github.com/UNM-CARC/QuickBytes/blob/master/logging_in.md)
+      * [Transerring data](https://github.com/UNM-CARC/QuickBytes/blob/master/transfer_data.md)
+      * [PBS/TORQUE](https://github.com/UNM-CARC/QuickBytes/blob/master/pbs-torque.md)
+      * [Sample PBS script](https://github.com/UNM-CARC/QuickBytes/blob/master/pbs_scripts2.md)
+      * [Submitting jobs](https://github.com/UNM-CARC/QuickBytes/blob/master/submitting_jobs.md)
+      * [Check running jobs](https://github.com/UNM-CARC/QuickBytes/blob/master/checking_on_running_jobs.md) 
+      * [Managing modules](https://github.com/UNM-CARC/QuickBytes/blob/master/module_management.md)
       * [Intro to Slurm](https://github.com/UNM-CARC/QuickBytes/blob/master/Intro_to_slurm.md)
       * [Converting PBS to Slurm](https://github.com/UNM-CARC/QuickBytes/blob/master/pbs2slurm.md)
-      * [Parallel MATLAB Server](https://github.com/UNM-CARC/QuickBytes/blob/master/ParallelMatlabServer.md)
       * [GNU Parallel](https://github.com/UNM-CARC/QuickBytes/blob/master/GNU%20Parallel.md)
    
    * Applications software
@@ -20,14 +25,21 @@ This table of contents will contain links to all the quickbytes, providing a sin
       * JupyterHub
          * [JupyterHub: Parallel Processing with MPI](https://github.com/UNM-CARC/QuickBytes/blob/master/parallelization_with%20Jupyterhub_using_mpi.md)
          * [Parallelization with JupyterHub using Dask and SciKit-learn](https://github.com/UNM-CARC/QuickBytes/blob/master/parallel_jupyterhub_with_dask_and_scikit-learn.md)
+      * Anaconda
+         * [Intro to Anaconda]()
+         * [Anaconda pip channels](https://github.com/UNM-CARC/QuickBytes/blob/master/anaconda_pip_channels.md)
+      * R
+         * [R Programming in HPC](https://github.com/UNM-CARC/QuickBytes/blob/master/R_usage.md)
+         * [R at CARC](https://github.com/UNM-CARC/QuickBytes/tree/master/R_at_CARC)
       * [Paraview](https://github.com/UNM-CARC/QuickBytes/blob/master/paraview.md)
       * [Installing Deep Learning Library in Xena](https://github.com/UNM-CARC/QuickBytes/blob/master/Install%20deep%20learning%20packages.md)
       * [Tensorflow](https://github.com/UNM-CARC/QuickBytes/blob/master/Tensorflow_documentation.md)
-      * [R Programming in HPC](https://github.com/UNM-CARC/QuickBytes/blob/master/R_usage.md)
       * [Gurobi optimizer with R](https://github.com/UNM-CARC/QuickBytes/blob/master/Gurobi%20optimizer%20with%20R.md)
       * [Docker and Singularity](https://github.com/UNM-CARC/QuickBytes/blob/master/singularity-markdown-version.md)
       * [Haskell at CARC](https://github.com/UNM-CARC/QuickBytes/blob/master/haskell.md)
       * [BEAST at CARC](https://github.com/UNM-CARC/QuickBytes/blob/master/Beast_at_CARC.md)
+      * [X11 Forwarding]()
+      * [Spark]()
      
   
       

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ Quickbytes are tutorials designed to help CARC users.
 
    * Running jobs
       * [Logging in](https://github.com/UNM-CARC/QuickBytes/blob/master/logging_in.md)
+      * [SSH keys and Config file](https://github.com/UNM-CARC/QuickBytes/blob/table-of-contents-readme/ssh_keygen_config.md)
       * [Transerring data](https://github.com/UNM-CARC/QuickBytes/blob/master/transfer_data.md)
       * [PBS/TORQUE](https://github.com/UNM-CARC/QuickBytes/blob/master/pbs-torque.md)
       * [Sample PBS script](https://github.com/UNM-CARC/QuickBytes/blob/master/pbs_scripts2.md)


### PR DESCRIPTION
Added all the basic user pages, as well as anaconda. The link for spark and X11 are not there actually yet. Also the anaconda intro link needs to be approved by Matthew so I can add the link from the master.