### PR TITLE
Paraview_slava_suggestions

### DIFF
--- a/Paraview_Hopper.md
+++ b/Paraview_Hopper.md
@@ -123,3 +123,4 @@ The point of having a separate data server and render server is the ability to u
 Thus, we recommend on almost all instances simply using the single pvserver. This document does not describe how to launch data server / render server jobs. Even if you really feel like this mode is right for you, it is best to first to configure your server in single server mode. From there, establishing the data server / render server should be easier. 
 
 More information Setting up ParaView Server, [Click Here.](https://www.paraview.org/Wiki/Setting_up_a_ParaView_Server) and If you would like to run paraview without a GUI interface, you can use the "pvpython" instead of pvserver https://www.paraview.org/Wiki/PvPython_and_PvBatch
+


### PR DESCRIPTION
Paraview Direct Connection.
1. Add info about hopper003, hopper005 etc. "after performing in the 1st terminal mpiexec -np 64 ... , the system will response with a message of form:
Accepting connection(s): hopper003:11111
Here we copy the node name, particularly, hopper003. Next, in the 2nd terminal we put this name (hopper003) ..." in the command:
ssh -L 11111:hopper003:11111 YOUR_USER_NAME@hopper.alliance.unm.edu where YOUR_USER_NAME is you user name at CARC."

2. Warn users about possible freezing during an attempt to establish connection. In my case this freezing takes 1 min 45-55 sec outside CARC and around 1 minute inside the CARC building. Looks, Paraview is scanning the amount of free memory on all 64 cores/machines and this takes almost 2 minutes. This freezing takes place with or without an active the Memory Inspector in Paraview.

3. Warn users that in order to reconnect they should launch "mpiexec -np 64 ..." in 1st terminal again.

4. I would add to users: "Do not forget, that the working time of Paraview is limited by the time you stated in salloc  command". 
+ Describe a way, how users can check their remaining machine time. Like "squeue --me" or "watch -n 0.1 squeue --me" 
in the 2nd terminal.

5.1. If a user performs salloc for a period of time and this time goes up when Paraview is still working. What should a user do ?

5.2. If a user allocated a period of time. Time is finished, and a new allocation of time is need. The user should be aware that during the a new time allocation the name / address (like "hopper005") may change to a different name / address (like "hopper003"). I think, in this case a user will have to exit and to ssh to a new name / address in the 2nd terminal. If so, do we need to mention this reconnection to a POSSIBLY DIFFERENT NODE in the 2nd terminal ?