### PR TITLE
Revise PBS to Slurm conversion guide

### DIFF
--- a/pbs2slurm.md
+++ b/pbs2slurm.md
@@ -103,7 +103,7 @@ Below is a sample PBS script that runs `test.py`.
 
 cd "$PBS_O_WORKDIR"
 
-python test.py
+srun python test.py
 ```
 
 ---
@@ -126,7 +126,7 @@ The equivalent Slurm script is:
 
 cd "$SLURM_SUBMIT_DIR"
 
-python test.py
+srun python test.py
 ```
 
 Submit the job with:

--- a/pbs2slurm.md
+++ b/pbs2slurm.md
@@ -1,49 +1,94 @@
-Conversion of PBS script to Slurm script
-===================================
+# Converting a PBS Script to a Slurm Script
 
- 
- Most of the machines at CARC uses PBS/TORQUE for scheduling jobs in HPC. However, Taos uses the Simple Linux Utility for Resource Management, or SLURM, for scheduling jobs. Slurm is a little different from PBS in terms of syntax, commands used for resource allocation, job submission and monitoring, and setting of environment variables. Detailed documentation of Slurm can be found in this [link](https://slurm.schedmd.com/documentation.html). For submitting a job on Taos, you have to submit a Slurm script. If you already have a PBS script, it can be easily converted to Slurm without worrying about the technical details of Slurm. More details of submitting a [PBS](http://carc.unm.edu/user-support-2/using-carc-systems1/running-jobs/submitting-jobs.html) and [Slurm](https://github.com/UNM-CARC/QuickBytes/blob/master/Intro_to_slurm.md) can be found in their quickbytes links.
- 
-## Conversion of PBS to Slurm
+Most CARC systems historically supported PBS/TORQUE for scheduling jobs in HPC environments. However, current CARC systems primarily use Slurm (Simple Linux Utility for Resource Management) for job scheduling.
 
-For this purpose, we can use the cheet sheet tables below. The first table lists the most commonly used commands in PBS for submitting and monitoring jobs.
+> **Note:** PBS is **not supported on Easley**. Although PBS may still be available on Hopper, we recommend using **Slurm** for all new jobs and workflows to ensure compatibility across CARC systems and to align with current support and documentation.
 
-|  PBS Command        |  Slurm Command   | Command definition                  |
-|  ------------       |  -------------   | ------------------                  |
-| qsub \<job_script.pbs> |  sbatch \<job_script.slurm>  | Submit \<job-script>  to the queue|
-| qsub -I \<options>  |  salloc \<options> |  Requesting interactive job|
-|qstat -u \<user>    |   squeue -u \<user> | Status of jobs submitted by \<user> |
-| qstat -f \<job-id> | scontrol show job \<job-id\> | Display details of \<job-id> |
-| qdel \<job-id>     | scancel \<job-id> | Delete the listed \<job-id>|
-|pbsnodes \<options> | sinfo | Display all nodes with their information|
+Slurm differs from PBS in its syntax, commands for resource allocation, job submission and monitoring, and environment variables.
 
-Now let's take a look at the commands used for resource allocation which goes into the PBS/SLURM script. In both cases, the script has to be initialized by the shell interpreter. Bash shell can be initialized in both PBS and SLURM by `#!/bin/bash/`
-The resource allocation in PBS is precceded by `#PBS`
- and `#SBATCH` in SLURM. Let's look at various commands used for allocating resources.
- 
-|  PBS Command        |  Slurm Command   | Command definition                  |
-|  ------------       |  -------------   | ------------------                  |
-|-N <name> | --job-name= \<name>| Name of the job to submit|
-|-l procs= \<N> |--ntasks= \<N> | N processes to run|
-|-l nodes=a:ppn=b | --ntasks= \<product of a and b> | a*b processes to run |
-|-l walltime=\<HH:MM:SS>|--time=\<HH:MM:SS> | Maximum time required to finish the job|
-|-l mem=\<Memory> | --mem = \<Memory> | Memory required per node|
-|-l M \<email> | --mail-user=\<email>| Email ID for sending the job alerts to the user |
-|-l m \<a,b,e\> |  --mail-type=\<BEGIN,END,FAIL,REQUEUE,ALL> | Sending email alerts at different situations|
-|-o \<out_file>|--output=\<out_file>| Name of the output file|
-|-e \<error_file> | --error=\<error_file>| Name of the file to write out the error/warning during execution|
-|-j oe| Default in Slurm | Merge output and error files|
+Detailed Slurm documentation is available here:
+https://slurm.schedmd.com/documentation.html
 
-Let's look at different ways to set environment variable within the PBS/Slurm job.
+To submit jobs on Slurm-based systems, you must submit a Slurm job script. If you already have a PBS script, converting it to Slurm is usually straightforward.
 
-|  PBS Variable        |  Slurm Variable   | Variable definition                  |
-|  ------------       |  -------------   | ------------------                  |
-|$PBS\_O_HOST | $SLURM\_SUBMIT_HOST | Hostname from which job was submitted|
-|$PBS\_JOBID | $SLURM\_JOB_ID | ID of the job sumitted|
-|$PBS\_O_WORKDIR | $SLURM\_SUBMIT_DIR| Name of the directory from which job was submited|
-|cat $PBS\_NODEFILE | $SLURM\_JOB_NODELIST| In PBS, a file containing allocated nodes/hostnames. In Slurm, a variable containing allocated nodes/hostnames.|
+Additional references:
 
-Now using the commands in the above tables,  we can easily convert a PBS script to a Slurm script. First let us look at a sample PBS script to run a python script test.py.
+* PBS job submission: http://carc.unm.edu/user-support-2/using-carc-systems1/running-jobs/submitting-jobs.html
+* Slurm QuickBytes: https://github.com/UNM-CARC/QuickBytes/blob/master/Intro_to_slurm.md
+
+---
+
+## Converting PBS Commands to Slurm Commands
+
+The table below lists commonly used PBS commands and their Slurm equivalents.
+
+| PBS Command             | Slurm Command                | Description                                     |
+| ----------------------- | ---------------------------- | ----------------------------------------------- |
+| `qsub <job_script.pbs>` | `sbatch <job_script.slurm>`  | Submit a batch job                              |
+| `qsub -I <options>`     | `salloc <options>`           | Request an interactive job                      |
+| `qstat -u <user>`       | `squeue -u <user>`           | Display jobs submitted by a user                |
+| `qstat -f <job-id>`     | `scontrol show job <job-id>` | Show detailed information for a job             |
+| `qdel <job-id>`         | `scancel <job-id>`           | Cancel a job                                    |
+| `pbsnodes <options>`    | `sinfo`                      | Display available nodes and cluster information |
+
+---
+
+## Resource Allocation Directives
+
+Both PBS and Slurm scripts begin with a shell interpreter declaration.
+
+Use:
+
+```bash
+#!/bin/bash
+```
+
+Resource directives are prefixed with:
+
+* `#PBS` for PBS
+* `#SBATCH` for Slurm
+
+Common resource allocation options are shown below.
+
+| PBS Directive            | Slurm Directive                               | Description                               |
+| ------------------------ | --------------------------------------------- | ----------------------------------------- |
+| `-N <name>`              | `--job-name=<name>`                           | Job name                                  |
+| `-l procs=<N>`           | `--ntasks=<N>`                                | Number of tasks/processes                 |
+| `-l nodes=a:ppn=b`       | `--nodes=a` + `--ntasks-per-node=b`           | Request `a` nodes with `b` tasks per node |
+| `-l walltime=<HH:MM:SS>` | `--time=<HH:MM:SS>`                           | Maximum wall-clock runtime                |
+| `-l mem=<memory>`        | `--mem=<memory>`                              | Memory requested per node                 |
+| `-M <email>`             | `--mail-user=<email>`                         | Email address for notifications           |
+| `-m <a,b,e>`             | `--mail-type=BEGIN,END,FAIL,REQUEUE,ALL`      | Email notification conditions             |
+| `-o <out_file>`          | `--output=<out_file>`                         | Standard output file                      |
+| `-e <error_file>`        | `--error=<error_file>`                        | Standard error file                       |
+| `-j oe`                  | Default behavior in many Slurm configurations | Combine stdout and stderr                 |
+
+> **Recommendation:** Prefer `--nodes` and `--ntasks-per-node` instead of collapsing everything into `--ntasks`, since this maps more directly to how resources are allocated in Slurm.
+
+---
+
+## Environment Variables
+
+PBS and Slurm expose similar environment variables during job execution.
+
+| PBS Variable        | Slurm Variable        | Description                                |
+| ------------------- | --------------------- | ------------------------------------------ |
+| `$PBS_O_HOST`       | `$SLURM_SUBMIT_HOST`  | Host where the job was submitted           |
+| `$PBS_JOBID`        | `$SLURM_JOB_ID`       | Job ID                                     |
+| `$PBS_O_WORKDIR`    | `$SLURM_SUBMIT_DIR`   | Directory from which the job was submitted |
+| `cat $PBS_NODEFILE` | `$SLURM_JOB_NODELIST` | Allocated nodes                            |
+
+If you need individual node names in Slurm:
+
+```bash
+scontrol show hostnames $SLURM_JOB_NODELIST
+```
+
+---
+
+## Example: PBS Script
+
+Below is a sample PBS script that runs `test.py`.
 
 ```bash
 #!/bin/bash
@@ -51,21 +96,27 @@ Now using the commands in the above tables,  we can easily convert a PBS script 
 #PBS -l nodes=1:ppn=1
 #PBS -l walltime=01:00:00
 #PBS -N test
-#PBS -o test_out
-#PBS -e test_error
+#PBS -o test.out
+#PBS -e test.err
 #PBS -m bae
 #PBS -M user@unm.edu
 
-cd $PBS_O_WORKDIR/
-python test.py
+cd "$PBS_O_WORKDIR"
 
+python test.py
 ```
-The corresponding Slurm script for the above PBS script can be written as
+
+---
+
+## Equivalent Slurm Script
+
+The equivalent Slurm script is:
 
 ```bash
 #!/bin/bash
 
-#SBATCH --ntasks=1
+#SBATCH --nodes=1
+#SBATCH --ntasks-per-node=1
 #SBATCH --time=01:00:00
 #SBATCH --job-name=test
 #SBATCH --output=test.out
@@ -73,10 +124,13 @@ The corresponding Slurm script for the above PBS script can be written as
 #SBATCH --mail-type=BEGIN,FAIL,END
 #SBATCH --mail-user=user@unm.edu
 
-cd $SLURM_SUBMIT_DIR/
-python test.py
+cd "$SLURM_SUBMIT_DIR"
 
+python test.py
 ```
 
+Submit the job with:
 
-
+```bash
+sbatch job_script.slurm
+```

--- a/pbs2slurm.md
+++ b/pbs2slurm.md
@@ -135,4 +135,4 @@ Submit the job with:
 sbatch job_script.slurm
 ```
 
-*This quickbyte was validated on 6/23/2026*
+*This QuickByte was validated on 6/23/2026*

--- a/pbs2slurm.md
+++ b/pbs2slurm.md
@@ -134,3 +134,5 @@ Submit the job with:
 ```bash
 sbatch job_script.slurm
 ```
+
+*This quickbyte was validated on 6/23/2026*

--- a/pbs2slurm.md
+++ b/pbs2slurm.md
@@ -23,7 +23,7 @@ Additional references:
 The table below lists commonly used PBS commands and their Slurm equivalents.
 
 | PBS Command             | Slurm Command                | Description                                     |
-| ----------------------- | ---------------------------- | ----------------------------------------------- |
+| ----------------------- | ----------------------------- | ----------------------------------------------- |
 | `qsub <job_script.pbs>` | `sbatch <job_script.slurm>`  | Submit a batch job                              |
 | `qsub -I <options>`     | `salloc <options>`           | Request an interactive job                      |
 | `qstat -u <user>`       | `squeue -u <user>`           | Display jobs submitted by a user                |
@@ -67,12 +67,22 @@ Common resource allocation options are shown below.
 
 ---
 
+## Running Commands with `srun`
+
+In Slurm, program execution lines within a batch script should generally be prefixed with `srun`. This ensures the command is properly launched on the allocated compute resources (rather than just on the node that happens to execute the script), and lets Slurm track and account for the resources that command actually uses. For single-task jobs the difference may not be obvious, but for multi-task or multi-node jobs, omitting `srun` can cause your program to run incorrectly or only on a single task/node instead of being distributed as requested.
+
+```bash
+srun python test.py
+```
+
+---
+
 ## Environment Variables
 
 PBS and Slurm expose similar environment variables during job execution.
 
 | PBS Variable        | Slurm Variable        | Description                                |
-| ------------------- | --------------------- | ------------------------------------------ |
+| ------------------- | ---------------------- | ------------------------------------------ |
 | `$PBS_O_HOST`       | `$SLURM_SUBMIT_HOST`  | Host where the job was submitted           |
 | `$PBS_JOBID`        | `$SLURM_JOB_ID`       | Job ID                                     |
 | `$PBS_O_WORKDIR`    | `$SLURM_SUBMIT_DIR`   | Directory from which the job was submitted |
@@ -103,7 +113,7 @@ Below is a sample PBS script that runs `test.py`.
 
 cd "$PBS_O_WORKDIR"
 
-srun python test.py
+python test.py
 ```
 
 ---
@@ -117,14 +127,14 @@ The equivalent Slurm script is:
 
 #SBATCH --nodes=1
 #SBATCH --ntasks-per-node=1
-#SBATCH --time=01:00:00
+#SBATCH --time=00:05:00
 #SBATCH --job-name=test
 #SBATCH --output=test.out
 #SBATCH --error=test.err
-#SBATCH --mail-type=BEGIN,FAIL,END
-#SBATCH --mail-user=user@unm.edu
 
 cd "$SLURM_SUBMIT_DIR"
+
+module load miniconda3
 
 srun python test.py
 ```
@@ -135,4 +145,4 @@ Submit the job with:
 sbatch job_script.slurm
 ```
 
-*This QuickByte was validated on 6/23/2026*
+*This quickbyte was validated on 6/25/2026*


### PR DESCRIPTION
Updated the document to provide a clearer comparison between PBS and Slurm commands, including resource allocation directives and environment variables. Added notes on the transition from PBS to Slurm and provided examples of job scripts.