### PR TITLE
install_perl_libraries.md

### DIFF
--- a/install_perl_libraries.md
+++ b/install_perl_libraries.md
@@ -4,7 +4,7 @@ Perl libraries can be installed to your home directory.
 
 First, load a perl module.
 Use `module spider perl` to view available perl modules on the cluster you are using.
-In this example we will use a perl module available on Easley (there's no separate compiler module to load first — Easley's perl modules don't need one).
+In this example we will use a perl module available on Easley. Easley's perl modules don't need a separate compiler module loaded first.
 ```bash
 $> module load perl/5.40.0-kptf
 ``` 

--- a/install_perl_libraries.md
+++ b/install_perl_libraries.md
@@ -4,10 +4,9 @@ Perl libraries can be installed to your home directory.
 
 First, load a perl module.
 Use `module spider perl` to view available perl modules on the cluster you are using.
-In this example we will use a perl module available on the Hopper cluster.
+In this example we will use a perl module available on Easley (there's no separate compiler module to load first — Easley's perl modules don't need one).
 ```bash
-$> module load intel/20.0.4
-$> module load perl/5.32.0-sw3s
+$> module load perl/5.40.0-kptf
 ``` 
 
 Next, start an interactive cpan shell:


### PR DESCRIPTION
intel/20.0.4 module is gone, dropped it. bumped perl version to one that actually exists

Found a consistent issue while retesting: the doc's last env-setup line, `eval $(perl -I$HOME/perl5/lib/perl5 -Mlocal::lib)` gives this exact error:

```
Can't locate local/lib.pm in @INC (you may need to install the local::lib module) (@INC entries checked: /users/hfricke/perl5/lib/perl5 /users/hfricke/perl5/lib/perl5 /opt/spack/.../perl-5.40.0-kptffn5nydhdqbso5dxh5t2nw7ld6pxr/lib/perl5 ... /lib/5.40.0). BEGIN failed--compilation aborted.
```
But as far as I can tell its a harmless error