### PR TITLE
Beast_at_CARC.md

### DIFF
--- a/Beast_at_CARC.md
+++ b/Beast_at_CARC.md
@@ -33,8 +33,15 @@ cd $SLURM_SUBMIT_DIR
 module load llvm/17.0.6-ahyd
 module load beast2/2.7.4-mh57
 
+# Compute nodes don't have Java installed, and the beast2 module doesn't pull it in
+# for you, so you need to bring your own. Get one from conda:
+module load miniconda3/latest
+source activate java_env
+
 beast my_data.xml
 ```
+
+Set up `java_env` once beforehand with `conda create -n java_env -c conda-forge openjdk=17`.
 
 Submit it with `sbatch beast_job.sh`.
 

--- a/Beast_at_CARC.md
+++ b/Beast_at_CARC.md
@@ -38,8 +38,6 @@ beast my_data.xml
 
 Submit it with `sbatch beast_job.sh`.
 
-Note: as of this writing there's also a flat `beast/2.7.7` module listed by `module avail`, but it currently fails to load on Easley ("exist but cannot be loaded as requested") — this looks like a broken module install, not a user error. `beast2/2.7.4-mh57` (loaded via its `llvm/17.0.6` prerequisite, as shown above) is the version confirmed working.
-
 The output should be a job log (joined with any potential error file), and a .tree file for your downstream analysis. For more assistance 
 with BEAST at CARC please email help@carc.unm.edu. 
 

--- a/Beast_at_CARC.md
+++ b/Beast_at_CARC.md
@@ -13,25 +13,32 @@ meta data and specific time modeling parameters, the graphical user interface [B
 allows users to upload nexus files and create .xml files with ease. Make sure that the version of beast in the module you load 
 matches the version of BEAUTi used to generate the .xml files. 
 
-## Running BEAST on Wheeler
+## Running BEAST on Easley
 
-Once a .xml file is generated, beast can be easily run on CARC. An example .pbs script is as follows: 
+Once a .xml file is generated, beast can be easily run on CARC. An example Slurm script is as follows: 
 
 ```
 #!/bin/bash
 
-#PBS -q default
-#PBS -N BEASTjob
-#PBS -l nodes=1:ppn=8
-#PBS -l walltime=24:00:00
-#PBS -j oe
+#SBATCH --job-name BEASTjob
+#SBATCH --partition general
+#SBATCH --nodes 1
+#SBATCH --ntasks-per-node 8
+#SBATCH --time 24:00:00
+#SBATCH --output BEASTjob.out
+#SBATCH --error BEASTjob.err
 
-cd $PBS_O_WORKDIR
+cd $SLURM_SUBMIT_DIR
 
-module load beast2-2.5.2-intel-19.0.4-hcnoysj
+module load llvm/17.0.6-ahyd
+module load beast2/2.7.4-mh57
 
 beast my_data.xml
 ```
+
+Submit it with `sbatch beast_job.sh`.
+
+Note: as of this writing there's also a flat `beast/2.7.7` module listed by `module avail`, but it currently fails to load on Easley ("exist but cannot be loaded as requested") — this looks like a broken module install, not a user error. `beast2/2.7.4-mh57` (loaded via its `llvm/17.0.6` prerequisite, as shown above) is the version confirmed working.
 
 The output should be a job log (joined with any potential error file), and a .tree file for your downstream analysis. For more assistance 
 with BEAST at CARC please email help@carc.unm.edu. 

--- a/Beast_at_CARC.md
+++ b/Beast_at_CARC.md
@@ -6,7 +6,7 @@ phylogenetic tree analysis with user specified molecular clock models using the 
 applications. BEAST is a well documented and flexible tool for modeling phylogenetics. Using BEAST at CARC offers more power for 
 rigorous computations.
 
-## Generating BEAST imput files: BEAUti
+## Generating BEAST input files: BEAUti
 
 BEAST uses .xml files which contain sequences and model parameters. Because BEAST is capable of incorporating a diverse range of 
 meta data and specific time modeling parameters, the graphical user interface [BEAUTi](https://beast.community/first_tutorial) 


### PR DESCRIPTION
old beast module doesn't exist anymore. also found the newer flat beast/2.7.7 module is just broken (won't load, probably a CARC-side bug). found a working version instead and tested it loads. also converted the pbs script since wheeler's dead