### PR TITLE
ssh_keygen_config.md

### DIFF
--- a/ssh_keygen_config.md
+++ b/ssh_keygen_config.md
@@ -47,16 +47,13 @@ Since your home directory is shared across all machines at CARC you only need to
 To make logging in to CARC even easier we also recommend setting up a ssh config file which allows you to simply type `ssh machinename` instead of your username at the machine address. To set up this file simply copy the example below and save it to a text document in your `ssh` folder, which is found at `~/.ssh/`. Change the user to your CARC username and you are set to log in quickly and efficiently. You can add machines based on which ones you have access to. 
 
 
-    Host wheeler
-        hostname wheeler.alliance.unm.edu
+    Host easley
+        hostname easley.alliance.unm.edu
         user CHANGEME
+        ForwardX11 yes
         port 22
     Host hopper
         hostname hopper.alliance.unm.edu
-        user CHANGEME
-        port 22
-    Host xena
-        hostname xena.alliance.unm.edu
         user CHANGEME
         ForwardX11 yes
         port 22
@@ -71,7 +68,7 @@ Note that on the CARC clusters by default, your ssh configuration file will cont
     IdentityFile ~/.ssh/cluster
     StrictHostKeyChecking=no
 
-This helps ensure you're able to connect freely across all of the CARC clusters, for example while logged in to hopper you can just type `ssh xena`.
+This helps ensure you're able to connect freely across all of the CARC clusters, for example while logged in to hopper you can just type `ssh easley`.
 
 The issue here will arise if you need to add a new ssh key for some reason, say, you need to add an ssh key so you're able to make edits to a git repository from the CARC clusters. If this is the case, you can start by creating a new ssh key as explained in the previous steps of this tutorial. 
 

--- a/ssh_keygen_config.md
+++ b/ssh_keygen_config.md
@@ -11,7 +11,7 @@ First, set up your ssh key. To do this type in the terminal prompt:
 
 You will then be asked which file you would like to save your new key under. Press enter here so it will be saved at the default location.
 
-Next, it will ask you to enter a passphrase. We rcommend you add a passphrase. You'll enter your password here, and then confirm it by entering that same password a second time. 
+Next, it will ask you to enter a passphrase. We recommend you add a passphrase. You'll enter your password here, and then confirm it by entering that same password a second time. 
 
 After this point, your ssh key has been created. You should see the randomart image for your key:
 
@@ -79,6 +79,6 @@ You should then edit your `~/.ssh/config` file as mentioned above, and change th
     IdentityFile ~/.ssh/cluster
     StrictHostKeyChecking=no
 
-This will ensure git will use the default key on the system when cloning with ssh (which will be the new one you just created), and will properly verify your credentials after adding the new public key to your github account. If you do not do this step, you will recevie a permision error when trying to clone or push to a git repo using ssh.
+This will ensure git will use the default key on the system when cloning with ssh (which will be the new one you just created), and will properly verify your credentials after adding the new public key to your github account. If you do not do this step, you will receive a permission error when trying to clone or push to a git repo using ssh.
 
 *This quickbyte was validated on 3/27/2025*


### PR DESCRIPTION
example config still had wheeler and xena in it, swapped for easley/hopper. tested ssh easley from inside hopper actually works passwordless like the doc claims