### PR TITLE
anaconda_general_intro.md, anaconda_intro.md, anaconda_pip_channels.md

### DIFF
--- a/anaconda_general_intro.md
+++ b/anaconda_general_intro.md
@@ -1,7 +1,7 @@
-# Anaconda
-### What is Anaconda?
+# Miniconda
+### What is Miniconda?
 
-At a basic level Anaconda is a distribution of Python and R, although there is an emphasis on working with python, that provides access collections of associated packages optimized specifically for data science maintained in repositories. The installation and management of these packages is handled with the Anaconda package manager Conda. While initially focused mainly on python packages the repositories hosted by Anaconda and others now house a large collection of non-python packages.  
+At a basic level Miniconda is a minimal installer for Conda, the package and environment manager originally built for the Anaconda Python/R distribution. Rather than bundling hundreds of data science packages up front like the full Anaconda distribution does, Miniconda gives you just Conda itself and a small base environment, and you install only the packages you actually need from there. This is what CARC provides via the `miniconda3` module. The `anaconda3` module has been retired.
 
 Conda is more than just a package manager however, it also creates and manages the environments that packages are installed in to. The use of environments to isolate software means you can have multiple versions of the same software installed in different environments and avoid conflicts or incompatibilities between software or dependencies. This is accomplished by installing packages into a separate directory which is then appended to your `PATH` when that environment is activated.
 

--- a/anaconda_intro.md
+++ b/anaconda_intro.md
@@ -16,146 +16,73 @@ We use `conda` to create new environments and install/upgrade packages within en
 
 Avoid pinning very old Python versions like 3.5 here. Besides being long past end-of-life, asking conda to solve an environment against years of since-released package history can make dependency resolution extremely slow or effectively hang.
 
-The command you are calling here is `conda` and you are telling it you want to `create` a new environment named TensorFlow with the packages python version 3.5 specifically, pandas, and tensorflow. When you enter this command `conda` prints out the plan for this environment to `stdout`:
+The command you are calling here is `conda` and you are telling it you want to `create` a new environment named TensorFlow with the packages python version 3.11 specifically, pandas, and tensorflow. When you enter this command `conda` prints out the plan for this environment to `stdout`:
 
 ```bash
-Solving environment: done
+conda create --name TensorFlow python=3.11 pandas tensorflow
+```
 
+```
 ## Package Plan ##
 
   environment location: /users/yourusername/.conda/envs/TensorFlow
 
   added / updated specs:
     - pandas
-    - python=3.5
+    - python=3.11
     - tensorflow
 
 
 The following packages will be downloaded:
 
-    package                    |            build
-    ---------------------------|-----------------
-    certifi-2018.8.24          |           py35_1         139 KB
-    termcolor-1.1.0            |           py35_1           7 KB
-    pip-10.0.1                 |           py35_0         1.8 MB
-    pytz-2018.5                |           py35_0         231 KB
-    protobuf-3.6.0             |   py35hf484d3e_0         615 KB
-    werkzeug-0.14.1            |           py35_0         426 KB
-    astor-0.7.1                |           py35_0          43 KB
-    libprotobuf-3.6.0          |       hdbcaa40_0         4.1 MB
-    markdown-2.6.11            |           py35_0         104 KB
-    mkl_fft-1.0.4              |   py35h4414c95_1         148 KB
-    mkl_random-1.0.1           |   py35h629b387_0         364 KB
-    tensorboard-1.10.0         |   py35hf484d3e_0         3.3 MB
-    tensorflow-base-1.10.0     |mkl_py35h3c3e929_0        82.1 MB
-    python-dateutil-2.7.3      |           py35_0         261 KB
-    numpy-base-1.15.1          |   py35h81de0dd_0         4.2 MB
-    wheel-0.31.1               |           py35_0          63 KB
-    _tflow_1100_select-0.0.3   |              mkl           2 KB
-    python-3.5.5               |       hc3d631a_4        28.3 MB
-    setuptools-40.2.0          |           py35_0         571 KB
-    grpcio-1.12.1              |   py35hdbcaa40_0         1.7 MB
-    gast-0.2.0                 |           py35_0          15 KB
-    absl-py-0.4.0              |   py35h28b3542_0         144 KB
-    six-1.11.0                 |   py35h423b573_1          21 KB
-    tensorflow-1.10.0          |mkl_py35heddcb22_0           4 KB
-    pandas-0.23.4              |   py35h04863e7_0        10.0 MB
-    numpy-1.15.1               |   py35h3b04361_0          37 KB
+    package                     |            build
+    ----------------------------|-----------------
+    pandas-3.0.5                |  py311h8032f78_1        14.5 MB  conda-forge
+    hdf5-2.1.0                  |nompi_h654f344_110         3.9 MB  conda-forge
+    python-flatbuffers-25.12.19 |     pyh9d96877_0          35 KB  conda-forge
     ------------------------------------------------------------
-                                           Total:       138.6 MB
+                                           Total:        20.5 MB
 
 The following NEW packages will be INSTALLED:
 
-    _tflow_1100_select: 0.0.3-mkl
-    absl-py:            0.4.0-py35h28b3542_0
-    astor:              0.7.1-py35_0
-    blas:               1.0-mkl
-    ca-certificates:    2018.03.07-0
-    certifi:            2018.8.24-py35_1
-    gast:               0.2.0-py35_0
-    grpcio:             1.12.1-py35hdbcaa40_0
-    intel-openmp:       2018.0.3-0
-    libedit:            3.1.20170329-h6b74fdf_2
-    libffi:             3.2.1-hd88cf55_4
-    libgcc-ng:          8.2.0-hdf63c60_1
-    libgfortran-ng:     7.3.0-hdf63c60_0
-    libprotobuf:        3.6.0-hdbcaa40_0
-    libstdcxx-ng:       8.2.0-hdf63c60_1
-    markdown:           2.6.11-py35_0
-    mkl:                2018.0.3-1
-    mkl_fft:            1.0.4-py35h4414c95_1
-    mkl_random:         1.0.1-py35h629b387_0
-    ncurses:            6.1-hf484d3e_0
-    numpy:              1.15.1-py35h3b04361_0
-    numpy-base:         1.15.1-py35h81de0dd_0
-    openssl:            1.0.2p-h14c3975_0
-    pandas:             0.23.4-py35h04863e7_0
-    pip:                10.0.1-py35_0
-    protobuf:           3.6.0-py35hf484d3e_0
-    python:             3.5.5-hc3d631a_4
-    python-dateutil:    2.7.3-py35_0
-    pytz:               2018.5-py35_0
-    readline:           7.0-ha6073c6_4
-    setuptools:         40.2.0-py35_0
-    six:                1.11.0-py35h423b573_1
-    sqlite:             3.24.0-h84994c4_0
-    tensorboard:        1.10.0-py35hf484d3e_0
-    tensorflow:         1.10.0-mkl_py35heddcb22_0
-    tensorflow-base:    1.10.0-mkl_py35h3c3e929_0
-    termcolor:          1.1.0-py35_1
-    tk:                 8.6.7-hc745277_3
-    werkzeug:           0.14.1-py35_0
-    wheel:              0.31.1-py35_0
-    xz:                 5.2.4-h14c3975_4
-    zlib:               1.2.11-ha838bed_2
+    keras:              conda-forge/noarch::keras-3.15.0-pyh753f3f9_0
+    numpy:               conda-forge/linux-64::numpy-2.4.6-py311h2e04523_0
+    pandas:             conda-forge/linux-64::pandas-3.0.5-py311h8032f78_1
+    python:             conda-forge/linux-64::python-3.11.15-h7508c33_1_cpython
+    tensorboard:        conda-forge/noarch::tensorboard-2.19.0-pyhd8ed1ab_0
+    tensorflow:         conda-forge/linux-64::tensorflow-2.19.1-cpu_py311h7787b69_55
+    tensorflow-base:    conda-forge/linux-64::tensorflow-base-2.19.1-cpu_py311hf06be6a_55
+    ... (plus their shared-library dependencies)
 
 Proceed ([y]/n)?
 ```
 
-This gives you the list of all packages you requested to be installed and their dependencies, as well as the package version and build. Of note is the environment location pathway at the top of the package plan, you will notice that `conda` by default installs into your local directory and does not need administrative access to install packages. This means that you can administer your own Anaconda environments at CARC. 
+This gives you the list of all packages you requested to be installed and their dependencies, as well as the package version and build. Of note is the environment location pathway at the top of the package plan, you will notice that `conda` by default installs into your local directory and does not need administrative access to install packages. This means that you can administer your own Conda environments at CARC. 
 
-When you verify the package plan `conda` will proceed with downloading package binaries and installing them into the environment directory. You will see the progress of installation and a message with how to activate your environment once complete:
+When you verify the package plan `conda` will proceed with downloading package binaries and installing them into the environment directory. You will see a progress display during installation and a message with how to activate your environment once complete:
 
-```bash
-Downloading and Extracting Packages
-certifi-2018.8.24    |  139 KB | ####################################### | 100%
-python-3.6.6         | 15.4 MB | ####################################### | 100%
-tensorflow-base-1.10 | 55.3 MB | ####################################### | 100%
-setuptools-40.2.0    |  554 KB | ####################################### | 100%
-libprotobuf-3.6.0    |  3.8 MB | ####################################### | 100%
-sqlite-3.24.0        |  2.2 MB | ####################################### | 100%
-mkl-2018.0.3         | 149.2 MB| ###################################### | 100%
-mkl_random-1.0.1     |  349 KB | ####################################### | 100%
-mkl_fft-1.0.4        |  137 KB | ####################################### | 100%
-openssl-1.0.2p       |  3.4 MB | ####################################### | 100%
-six-1.11.0           |   21 KB | ####################################### | 100%
-tensorflow-1.10.0    |    4 KB | ####################################### | 100%
-numpy-base-1.15.1    |  4.0 MB | ####################################### | 100%
-protobuf-3.6.0       |  604 KB | ####################################### | 100%
-numpy-1.15.1         |   37 KB | ####################################### | 100%
-intel-openmp-2018.0. | 1004 KB | ####################################### | 100%
-absl-py-0.4.0        |  143 KB | ####################################### | 100%
-tensorboard-1.10.0   |  3.3 MB | ####################################### | 100%
-_tflow_1100_select-0 |    3 KB | ####################################### | 100%
+```
 Preparing transaction: done
 Verifying transaction: done
 Executing transaction: done
 #
-# To activate this environment, use:
-# > source activate TensorFlow
+# To activate this environment, use
 #
-# To deactivate an active environment, use:
-# > source deactivate
+#     $ conda activate TensorFlow
+#
+# To deactivate an active environment, use
+#
+#     $ conda deactivate
 #
 ```
 
-Now we have our machine learning environment created to run our machine learning python script. To activate the environment we just created you use the command `source activate my_environment_name`, which is `source activate TensorFlow` for this example. Remember to include the lines below in your PBS script when working with Anaconda environments:
+Now we have our machine learning environment created to run our machine learning python script. To activate the environment we just created you use the command `source activate my_environment_name`, which is `source activate TensorFlow` for this example — use `source activate`/`source deactivate` rather than `conda activate`/`conda deactivate` here, since `conda activate` reliably fails on Easley/Hopper with `CondaError: Run 'conda init' before 'conda activate'`, even right after running `conda init`. Remember to include the lines below in your Slurm script when working with Conda environments:
 
 ```bash
-# load anaconda software module
-module load anaconda3
+# load miniconda software module
+module load miniconda3/latest
 
-# activate your desired anaconda environment
+# activate your desired conda environment
 source activate environment_name
 ```
 For more information on managing environments visit the Conda documentation site at this [link](https://conda.io/docs/user-guide/index.html), or by adding the flag `--help` to any `conda` command, for example, `conda create --help` will print a help page for creating environments.

--- a/anaconda_intro.md
+++ b/anaconda_intro.md
@@ -14,7 +14,7 @@ We use `conda` to create new environments and install/upgrade packages within en
 
 `conda create --name TensorFlow python=3.11 pandas tensorflow`
 
-Avoid pinning very old Python versions like 3.5 here. Besides being long past end-of-life, asking conda to solve an environment against years of since-released package history can make dependency resolution extremely slow or effectively hang.
+Avoid pinning very old Python versions like 3.5 here. They're long past end-of-life, and asking conda to solve an environment against years of since-released package history can make dependency resolution extremely slow or effectively hang.
 
 The command you are calling here is `conda` and you are telling it you want to `create` a new environment named TensorFlow with the packages python version 3.11 specifically, pandas, and tensorflow. When you enter this command `conda` prints out the plan for this environment to `stdout`:
 
@@ -52,7 +52,7 @@ The following NEW packages will be INSTALLED:
     tensorboard:        conda-forge/noarch::tensorboard-2.19.0-pyhd8ed1ab_0
     tensorflow:         conda-forge/linux-64::tensorflow-2.19.1-cpu_py311h7787b69_55
     tensorflow-base:    conda-forge/linux-64::tensorflow-base-2.19.1-cpu_py311hf06be6a_55
-    ... (plus their shared-library dependencies)
+    ...
 
 Proceed ([y]/n)?
 ```
@@ -76,7 +76,7 @@ Executing transaction: done
 #
 ```
 
-Now we have our machine learning environment created to run our machine learning python script. To activate the environment we just created you use the command `source activate my_environment_name`, which is `source activate TensorFlow` for this example — use `source activate`/`source deactivate` rather than `conda activate`/`conda deactivate` here, since `conda activate` reliably fails on Easley/Hopper with `CondaError: Run 'conda init' before 'conda activate'`, even right after running `conda init`. Remember to include the lines below in your Slurm script when working with Conda environments:
+Now we have our machine learning environment created to run our machine learning python script. To activate the environment we just created you use the command `source activate my_environment_name`, which is `source activate TensorFlow` for this example. Remember to include the lines below in your Slurm script when working with Conda environments:
 
 ```bash
 # load miniconda software module

--- a/anaconda_intro.md
+++ b/anaconda_intro.md
@@ -1,18 +1,20 @@
-# Anaconda
+# Miniconda
 
-### What is Anaconda?
+### What is Miniconda?
 
-Fundamentally, Anaconda is a distribution of Python and R with a collection of associated packages optimized for data science. The installation and management of these packages is handled with the Anaconda package manager Conda. Conda is more than just a package manager however, it also creates and manages the environments that packages are installed in to. The usage of environments means you can have multiple versions of certain software installed in different environments and avoid conflicts or incompatibilities between software or dependencies. This is accomplished by installing packages into a separate directory which is then appended to your `PATH` when that environment is activated.
+Fundamentally, Miniconda is a minimal installer for Conda, the package and environment manager originally built for the Anaconda Python/R distribution — a collection of packages optimized for data science. Conda is more than just a package manager however, it also creates and manages the environments that packages are installed in to. The usage of environments means you can have multiple versions of certain software installed in different environments and avoid conflicts or incompatibilities between software or dependencies. This is accomplished by installing packages into a separate directory which is then appended to your `PATH` when that environment is activated.
 
 ### Creating a new conda environment
 
-Let's create an environment on Wheeler to run a python machine learning script that uses the TensorFlow library, python version 3.5, and the pandas library. Once you log in to Wheeler using `ssh` load the anaconda software module with the command:
+Let's create an environment on Easley to run a python machine learning script that uses the TensorFlow library and the pandas library. Once you log in to Easley using `ssh` load the miniconda software module with the command:
 
-`module load anaconda3`
+`module load miniconda3/latest`
 
 We use `conda` to create new environments and install/upgrade packages within environments. To create our machine learning environment we type:
 
-`conda create --name TensorFlow python=3.5 pandas tensorflow`
+`conda create --name TensorFlow python=3.11 pandas tensorflow`
+
+Avoid pinning very old Python versions like 3.5 here. Besides being long past end-of-life, asking conda to solve an environment against years of since-released package history can make dependency resolution extremely slow or effectively hang.
 
 The command you are calling here is `conda` and you are telling it you want to `create` a new environment named TensorFlow with the packages python version 3.5 specifically, pandas, and tensorflow. When you enter this command `conda` prints out the plan for this environment to `stdout`:
 

--- a/anaconda_pip_channels.md
+++ b/anaconda_pip_channels.md
@@ -7,13 +7,10 @@ For example, say you need the library psutil, but you specifically need version 
 ```bash
 $ conda search psutil=5.3
 Loading channels: done
-# Name                  Version           Build  Channel
-psutil                    5.3.1          py27_0  conda-forge
-psutil                    5.3.1  py27h4c169b4_0  pkgs/main
-psutil                    5.3.1          py35_0  conda-forge
-psutil                    5.3.1  py35h6e9e629_0  pkgs/main
-psutil                    5.3.1          py36_0  conda-forge
-psutil                    5.3.1  py36h0e357b8_0  pkgs/main
+# Name                       Version           Build  Channel
+psutil                         5.3.1          py27_0  conda-forge
+psutil                         5.3.1          py35_0  conda-forge
+psutil                         5.3.1          py36_0  conda-forge
 ```
 
 Unfortunately there are no packages built for psutil version 5.3.0. We can use pip to install the version we want however.
@@ -55,78 +52,38 @@ zlib                      1.2.11               ha838bed_2
 ```
 When installing packages using `pip` it is important to first activate the Conda environment that you want to install the package in since pip is strictly a package manager and cannot modify Conda environments from outside that environment. You can see that our psutil package, marked with a double asterisk, is version 5.3.0, just like we wanted. Under the 'build' column however you will see that `conda` is not sure which build it is since it was installed with `pip`, as indicated by the `<pip>` designator.
 #### Performance with Conda versus Pip
-One thing to note when installing packages is that it is always preferable to first install necessary packages with `conda` first, only then use `pip` to install only those packages that were not available through Anaconda repositories. 
+One thing to note when installing packages is that it is always preferable to first install necessary packages with `conda` first, only then use `pip` to install only those packages that were not available through your configured Conda channels. 
 It is usually best practice to install needed packages and dependencies with `conda` and use `pip` to install any remaining packages that were not available instead of vice versa.
 
 #### Adding package repositories (channels)
 
-Sometimes the default repositories, or channels for Conda, do not have the package you are looking for, but that does not mean that it is necessarily unavailable entirely. Say you are working with some Illumina sequence data and need the Burrows-Wheeler Aligner (bwa) in your pipeline, so you activate your bioinformatics environment and type `conda install bwa` which prints the following:
+Sometimes the default channels for Conda do not have the package you are looking for, but that does not mean it is necessarily unavailable entirely. CARC's `miniconda3` module is already configured with these default channels (check yours with `conda config --show channels`):
 
 ```bash
-Solving environment: failed
-
-PackagesNotFoundError: The following packages are not available from current channels:
-
-  - bwa
-
-Current channels:
-
-  - https://repo.anaconda.com/pkgs/main/linux-64
-  - https://repo.anaconda.com/pkgs/main/noarch
-  - https://repo.anaconda.com/pkgs/free/linux-64
-  - https://repo.anaconda.com/pkgs/free/noarch
-  - https://repo.anaconda.com/pkgs/r/linux-64
-  - https://repo.anaconda.com/pkgs/r/noarch
-  - https://repo.anaconda.com/pkgs/pro/linux-64
-  - https://repo.anaconda.com/pkgs/pro/noarch
-
-To search for alternate channels that may provide the conda package you're
-looking for, navigate to
-
-    https://anaconda.org
-
-and use the search bar at the top of the page.
-```
-We can search other channels that may have the package we are interested in with the `-c` flag. For example, BioConda is a large repository that hosts several thousand bioinformatics packages. We can search for our bwa package by specifying that channel.
-
-```bash
-$ conda search -c bioConda bwa
+channels:
+  - conda-forge
+  - nodefaults
+  - bioconda
 ```
 
-Which yields better results:
+Note that BioConda — a large repository of bioinformatics packages — is already a default channel here, unlike a stock Anaconda/Miniconda install. So a package like the Burrows-Wheeler Aligner (bwa), which lives in BioConda, is already found without specifying `-c bioconda`:
 
 ```bash
+$ conda search bwa
 Loading channels: done
 # Name                  Version           Build  Channel
-bwa                       0.5.9               0  bioConda
-bwa                       0.5.9               1  bioConda
-bwa                       0.6.2               0  bioConda
-bwa                       0.6.2               1  bioConda
-bwa                      0.7.3a               0  bioConda
-bwa                      0.7.3a               1  bioConda
-bwa                      0.7.3a      ha92aebf_2  bioConda
-bwa                       0.7.4      ha92aebf_0  bioConda
-bwa                       0.7.8               0  bioConda
-bwa                       0.7.8               1  bioConda
-bwa                       0.7.8      ha92aebf_2  bioConda
-bwa                      0.7.12               0  bioConda
-bwa                      0.7.12               1  bioConda
-bwa                      0.7.13               0  bioConda
-bwa                      0.7.13               1  bioConda
-bwa                      0.7.15               0  bioConda
-bwa                      0.7.15               1  bioConda
-bwa                      0.7.16      pl5.22.0_0  bioConda
-bwa                      0.7.17      ha92aebf_3  bioConda
-bwa                      0.7.17      pl5.22.0_0  bioConda
-bwa                      0.7.17      pl5.22.0_1  bioConda
-bwa                      0.7.17      pl5.22.0_2  bioConda
+bwa                       0.7.17      hed695b0_6  bioconda
+bwa                       0.7.17      hed695b0_7  bioconda
+bwa                       0.7.17      pl5.22.0_0  bioconda
+bwa                       0.7.18      h577a1d6_2  bioconda
+bwa                       0.7.19      h577a1d6_0  bioconda
 ```
 
-We can then install our bwa package using `conda install -c bioConda bwa` and continue with our analyses. You can permanently add channels by appending your `.condarc` file either directly in a text editor, or with `conda` by using the `config` command:
+If you do need a package from a channel that isn't in that default list, add it with `-c <channel>`, for example `conda search -c nvidia <package>`. You can permanently add a channel to your configuration with:
 
 ```bash
-$ conda config --append channels bioconda
+$ conda config --append channels <channel-name>
 ```
-This will permanently add the BioConda channel to your configuration file meaning Conda will automatically search BioConda as well as the default channels when looking for packages.
+This will permanently add that channel to your `.condarc` file, meaning Conda will automatically search it alongside conda-forge/bioconda when looking for packages.
 
 For more information on managing channels and installing with pip please refer to the Conda support documentation at this [link](https://conda.io/docs/user-guide/tasks/manage-channels.html).

--- a/anaconda_pip_channels.md
+++ b/anaconda_pip_channels.md
@@ -66,7 +66,7 @@ It is usually best practice to install needed packages and dependencies with `co
 
 #### Adding package repositories (channels)
 
-Sometimes the default channels for Conda do not have the package you are looking for, but that does not mean it is necessarily unavailable entirely. CARC's `miniconda3` module is already configured with these default channels (check yours with `conda config --show channels`):
+Sometimes the default channels for Conda do not have the package you are looking for, but that does not mean it is necessarily unavailable entirely. CARC's `miniconda3` module is already configured with these default channels. Check yours with `conda config --show channels`:
 
 ```bash
 channels:
@@ -75,7 +75,7 @@ channels:
   - bioconda
 ```
 
-Note that BioConda — a large repository of bioinformatics packages — is already a default channel here, unlike a stock Anaconda/Miniconda install. So a package like the Burrows-Wheeler Aligner (bwa), which lives in BioConda, is already found without specifying `-c bioconda`:
+BioConda, a large repository of bioinformatics packages, is already a default channel here, unlike a stock Anaconda/Miniconda install. So a package like the Burrows-Wheeler Aligner (bwa), which lives in BioConda, is already found without specifying `-c bioconda`:
 
 ```bash
 conda search bwa

--- a/anaconda_pip_channels.md
+++ b/anaconda_pip_channels.md
@@ -66,7 +66,7 @@ It is usually best practice to install needed packages and dependencies with `co
 
 #### Adding package repositories (channels)
 
-Sometimes the default channels for Conda do not have the package you are looking for, but that does not mean it is necessarily unavailable entirely. CARC's `miniconda3` module is already configured with these default channels. Check yours with `conda config --show channels`:
+Sometimes the default channels for Conda do not have the package you are looking for, but that does not mean it is necessarily unavailable entirely. CARC's `miniconda3` module is already configured with these default channels (check yours with `conda config --show channels`):
 
 ```bash
 channels:
@@ -75,7 +75,7 @@ channels:
   - bioconda
 ```
 
-BioConda, a large repository of bioinformatics packages, is already a default channel here, unlike a stock Anaconda/Miniconda install. So a package like the Burrows-Wheeler Aligner (bwa), which lives in BioConda, is already found without specifying `-c bioconda`:
+Note that BioConda — a large repository of bioinformatics packages — is already a default channel here, unlike a stock Anaconda/Miniconda install. So a package like the Burrows-Wheeler Aligner (bwa), which lives in BioConda, is already found without specifying `-c bioconda`:
 
 ```bash
 conda search bwa

--- a/anaconda_pip_channels.md
+++ b/anaconda_pip_channels.md
@@ -5,7 +5,10 @@ Not all versions of all software have Conda packages available however, especial
 For example, say you need the library psutil, but you specifically need version 5.3.0. When you search for psutil using `conda` you get the following:
 
 ```bash
-$ conda search psutil=5.3
+conda search psutil=5.3
+```
+
+```
 Loading channels: done
 # Name                       Version           Build  Channel
 psutil                         5.3.1          py27_0  conda-forge
@@ -16,9 +19,11 @@ psutil                         5.3.1          py36_0  conda-forge
 Unfortunately there are no packages built for psutil version 5.3.0. We can use pip to install the version we want however.
 
 ```bash
-$ source activate py-2.7
+source activate py-2.7
+pip install psutil==5.3.0
+```
 
-(py-2.7)$ pip install psutil==5.3.0
+```
 Collecting psutil==5.3.0
   Downloading https://files.pythonhosted.org/packages/1c/da/555e3ad3cad30f30bcf0d539cdeae5c8e7ef9e2a6078af645c70aa81e418/psutil-5.3.0.tar.gz (397kB)
     100% |████████████████████████████████| 399kB 1.3MB/s
@@ -26,10 +31,14 @@ Building wheels for collected packages: psutil
   Running setup.py bdist_wheel for psutil ... done
   Stored in directory: /users/yourusername/.cache/pip/wheels/ff/c5/4f/1ee2208203f1cfeda16e91fccd8bfce5f4840b683671729d57
 Successfully built psutil
+```
 
-(py-2.7)$ conda list
+```bash
+conda list
+```
 
-# packages in environment at /users/yourusername/.Conda/envs/py-2.7:
+```
+# packages in environment at /users/yourusername/.conda/envs/py-2.7:
 #
 # Name                    Version                   Build
 ca-certificates           2018.03.07                    0
@@ -69,7 +78,10 @@ channels:
 Note that BioConda — a large repository of bioinformatics packages — is already a default channel here, unlike a stock Anaconda/Miniconda install. So a package like the Burrows-Wheeler Aligner (bwa), which lives in BioConda, is already found without specifying `-c bioconda`:
 
 ```bash
-$ conda search bwa
+conda search bwa
+```
+
+```
 Loading channels: done
 # Name                  Version           Build  Channel
 bwa                       0.7.17      hed695b0_6  bioconda


### PR DESCRIPTION
anaconda3 module is gone, these were all still teaching it. switched to miniconda3

also found the pip channels doc was just wrong now - it says bwa needs -c bioconda but bioconda's already a default channel here so it's found without that flag. tested it and rewrote that part

also the TensorFlow example pinned python 3.5 which makes conda's solver basically hang trying to resolve it against years of newer package builds. bumped to 3.11, tested the dry run actually resolves fast