### PR TITLE
Using GPUs on Xena with MATLAB.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Quickbytes are tutorials designed to help CARC users.
          * [Running MATLAB jobs at CARC](https://github.com/UNM-CARC/QuickBytes/blob/master/running_matlab_jobs.md)
          * [Parallel MATLAB Server](https://github.com/UNM-CARC/QuickBytes/blob/master/ParallelMatlabServer.md)
          * [Parallel MATLAB batch submission](https://github.com/UNM-CARC/QuickBytes/blob/parallel_matlab_profile_creation/Parallel%20MATLAB%20profile%20setup%20and%20batch%20submission.md)
-         * [Using GPUs with MATLAB](https://github.com/UNM-CARC/QuickBytes/blob/master/Using%20GPUs%20on%20Xena%20with%20MATLAB.md)
+         * [Using GPUs with MATLAB](https://github.com/UNM-CARC/QuickBytes/blob/master/Using%20GPUs%20on%20Easley%20with%20MATLAB.md)
          * [MATLAB Deep Learning on Xena](https://github.com/UNM-CARC/QuickBytes/blob/master/MATLAB%20Deep%20Learning%20on%20Xena.md)
       * JupyterHub
          * [JupyterHub: Parallel Processing with MPI](https://github.com/UNM-CARC/QuickBytes/blob/master/parallelization_with%20Jupyterhub_using_mpi.md)

--- a/Using GPUs on Easley with MATLAB.md
+++ b/Using GPUs on Easley with MATLAB.md
@@ -145,7 +145,7 @@ This confirms that array A is not on the GPU, but array B is.
 ##### Retrieve Array from GPU <a name="1.1.5"></a>
 In order to retrieve an array from the GPU and put it back in the MATLAB workspace, use the `gather` function.
 It will copy the contents of an array on the GPU into a normal array.
-This is neccesary if you want to to perform non-GPU actions on your data after using the GPU.
+This is necessary if you want to perform non-GPU actions on your data after using the GPU.
 ```
 >> C = gather(B)
 ```
@@ -194,7 +194,7 @@ We will then create a Slurm script that schedules a job with a GPU to run the MA
 
 #### MATLAB Script <a name="1.2.1"></a>
 We will perform the `sqrt` function on a 5000x5000 array.
-The use of `tic` and `toc` allow us to time the seperate applications of `sqrt`.
+The use of `tic` and `toc` allow us to time the separate applications of `sqrt`.
 
 Create the following script with the name `gpu_matlab.m`:
 

--- a/Using GPUs on Easley with MATLAB.md
+++ b/Using GPUs on Easley with MATLAB.md
@@ -26,7 +26,7 @@ The following sections show how to access and utilize a GPU on Easley.
 
 ### Use GPU in Interactive Session <a name="1.1"></a>
 
-First, we will open MATLAB in an interactive session on an Easley compute node. Easley's GPU partitions are `h100` and `l40s` (H100 and L40S GPUs respectively) — request one with `--gres=gpu:<type>:<count>`.
+First, we will open MATLAB in an interactive session on an Easley compute node. Easley's GPU partitions are `h100` and `l40s`, giving you H100 and L40S GPUs respectively. Request one with `--gres=gpu:<type>:<count>`.
 
 #### Identify and Select GPU <a name="1.1.1"></a>
 
@@ -76,7 +76,7 @@ ans =
       1      "NVIDIA L40S"          "8.9"               true              false
 ```
 
-Next, you can tell MATLAB which GPU to use (pass in the desired index from the above table).
+Next, you can tell MATLAB which GPU to use. Pass in the desired index from the above table.
 If you do not do this, MATLAB will automatically grab the lowest index GPU when you try to use one.
 ```
 >> gpuDevice(1)

--- a/Using GPUs on Easley with MATLAB.md
+++ b/Using GPUs on Easley with MATLAB.md
@@ -1,6 +1,6 @@
 # Using GPUs with MATLAB
 
-1. [Using a single GPU on Xena](#1)
+1. [Using a single GPU on Easley](#1)
      1. [Use GPU in Interactive Session](#1.1)
           1. [Identify and Select GPU](#1.1.1)
           2. [Using Arrays on GPU](#1.1.2)
@@ -10,90 +10,92 @@
           6. [Use functions on GPU Arrays](#1.1.6)
      2. [Schedule a job](#1.2)
           1. [MATLAB Script](#1.2.1)
-          2. [PBS Script](#1.2.2)
-          3. [Slurm Script](#1.2.3)
-          4. [Submit Job to Queue](#1.2.4)
-2. [Using Multiple GPUs on a single Xena node](#2)
-    1. [MATLAB Script](#2.2)
+          2. [Slurm Script](#1.2.2)
+          3. [Submit Job to Queue](#1.2.3)
+2. [Using Multiple GPUs on a single Easley node](#2)
+    1. [MATLAB Script](#2.1)
     2. [Slurm Script](#2.2)
-    3. [Submit Job to Queue](#2.3) 
+    3. [Submit Job to Queue](#2.3)
 3. [Using Multiple Nodes with their own GPUs](#3)
 
 
-## Using a single GPU on Xena <a name="1"></a>
+## Using a single GPU on Easley <a name="1"></a>
 
 MATLAB allows the utilization of a single GPU that is part of a machine.
-The following sections show how to access and utilize a GPU on xena.
+The following sections show how to access and utilize a GPU on Easley.
 
 ### Use GPU in Interactive Session <a name="1.1"></a>
 
-First, we will open MATLAB in an interactive session on a xena compute node.
+First, we will open MATLAB in an interactive session on an Easley compute node. Easley's GPU partitions are `h100` and `l40s` (H100 and L40S GPUs respectively) — request one with `--gres=gpu:<type>:<count>`.
 
 #### Identify and Select GPU <a name="1.1.1"></a>
 
 Start by requesting an interactive session:
 
 ```bash
-xena:~$ srun -G 1 --pty bash
+easley-sn:~$ srun --partition l40s --gres=gpu:l40s:1 --pty bash
 ```
 
 Once you have a node allocated to you, load the MATLAB module and start a MATLAB session:
 
 ```bash
-xena01:~$ module load matlab
-xena01:~$ matlab
+easley055:~$ module load matlab/R2024b
+easley055:~$ matlab
+```
 
+```
 To get started, type doc.
 For product information, visit www.mathworks.com.
 >>
 ```
 
 Now you can check to see the number of GPUs available:
-```bash
+```
 >> gpuDeviceCount("available")
 ```
 You should see the following:
-```bash
+```
 ans = 
      1
 ```
 This means that you have access to a single GPU.
 
 To get information about the available gpus, use this function:
-```bash
+```
 >> gpuDeviceTable
 ```
-That will print something that looks like this on Xena:
-```bash
+That will print something that looks like this on Easley:
+```
 ans =
 
   1x5 table
 
-    Index        Name        ComputeCapability    DeviceAvailable    DeviceSelected
-    _____    ____________    _________________    _______________    ______________
+    Index        Name         ComputeCapability    DeviceAvailable    DeviceSelected
+    _____    _____________    _________________    _______________    ______________
 
-      1      "Tesla K40m"          "3.5"               true              false
+      1      "NVIDIA L40S"          "8.9"               true              false
 ```
 
 Next, you can tell MATLAB which GPU to use (pass in the desired index from the above table).
 If you do not do this, MATLAB will automatically grab the lowest index GPU when you try to use one.
-```bash
+```
 >> gpuDevice(1)
 ```
 
 Running the `gpuDeviceTable` command again shows this change:
-```bash
+```
 >> gpuDeviceTable
+```
 
+```
 ans =
 
   1x5 table
 
-    Index        Name        ComputeCapability    DeviceAvailable    DeviceSelected
-    _____    ____________    _________________    _______________    ______________
+    Index        Name         ComputeCapability    DeviceAvailable    DeviceSelected
+    _____    _____________    _________________    _______________    ______________
 
-      1      "Tesla K40m"          "3.5"               true              true
-
+      1      "NVIDIA L40S"          "8.9"               true              true
 ```
 
 #### Using Arrays on GPU <a name="1.1.2"></a>
@@ -104,28 +106,34 @@ For a full description of the `gpuArray` object, please visit the official MathW
 ##### Initialize Array <a name="1.1.3"></a>
 First, create a normal array using any method you like.
 In this example we will use the `magic(8)` function to create a magic square matrix that is 8x8.
-```bash
+```
 >> A = magic(8)
 ```
 Next, pass that into a `gpuArray` object.
 This will copy the contents of a normal array into an array on the GPU.
-```bash
+```
 >> B = gpuArray(A)
 ```
 
 ##### Test if array is on GPU <a name="1.1.4"></a>
 The `isgpuarray` function tests if an array is on a GPU:
-```bash
+```
 >> isgpuarray(A)
+```
 
+```
 ans =
 
   logical
 
    0
+```
 
+```
 >> isgpuarray(B)
+```
 
+```
 ans =
 
   logical
@@ -138,13 +146,15 @@ This confirms that array A is not on the GPU, but array B is.
 In order to retrieve an array from the GPU and put it back in the MATLAB workspace, use the `gather` function.
 It will copy the contents of an array on the GPU into a normal array.
 This is neccesary if you want to to perform non-GPU actions on your data after using the GPU.
-```bash
+```
 >> C = gather(B)
 ```
 Now, we can test to see if C is stored on the gpu:
-```bash
+```
 >> isgpuarray(C)
+```
 
+```
 ans =
 
   logical
@@ -155,20 +165,21 @@ ans =
 #### Use functions on GPU Arrays <a name="1.1.6"></a>
 To perform functions on `gpuArray` objects, use the `arrayfun` function.
 In this example, we will apply the MATLAB `sqrt` function to the array (B) that we created in the previous step:
-```bash
+```
 result = arrayfun(@sqrt,B)
 ```
 This will apply the `sqrt` function to every element in the GPU array.
 `result` is also a GPU array:
-```bash
+```
 >> isgpuarray(result)
+```
 
+```
 ans =
 
   logical
 
    1
-
 ```
 
 To see a list of MATLAB functions that are supported using gpus, visit [https://www.mathworks.com/help/parallel-computing/gpuarray.html](https://www.mathworks.com/help/parallel-computing/gpuarray.html)
@@ -178,7 +189,7 @@ You can also create your own functions to pass into `arrayfun`.
 ### Schedule a job <a name="1.2"></a>
 It is good idea to do everything using a batch script and avoid the mistakes associated with interactive computing.
 To get an idea of why performing functions on `gpuArray` objects is a good idea, let's create a simple MATLAB script that displays the amount of time it takes to perform the same computation on a cpu and on a gpu.
-We will then create a PBS script that schedules a job with a GPU to run the MATLAB script for us.
+We will then create a Slurm script that schedules a job with a GPU to run the MATLAB script for us.
 
 
 #### MATLAB Script <a name="1.2.1"></a>
@@ -187,7 +198,7 @@ The use of `tic` and `toc` allow us to time the seperate applications of `sqrt`.
 
 Create the following script with the name `gpu_matlab.m`:
 
-```bash 
+```matlab
 gpuDevice(1);
 
 A = magic(5000);
@@ -201,34 +212,12 @@ tic
 D = arrayfun(@sqrt,C);
 toc
 ```
-#### PBS Script <a name="1.2.2"></a>
 
-Now, let's create a PBS script called `gpu_matlab.pbs`. 
-Replace the `<DIR>` with the path to the directory containing the MATLAB script created above. 
-This script will request the desired resrouces, load the MATLAB module, then run the script.
-The output of the script will be sent to the file: `gpu_matlab.out`
+#### Slurm Script <a name="1.2.2"></a>
 
-```bash
-#!/bin/bash
-
-#PBS -N gpu_test
-#PBS -l walltime=00:05:00
-#PBS -l nodes=1:ppn=1:gpus=1
-#PBS -j oe
-
-cd <DIR>
-
-module load matlab
-
-matlab -nodisplay -r gpu_matlab > gpu_matlab.out
-
-```
-
-#### Slurm Script <a name="1.2.3"></a>
-
-Now, let's create a Slurm script called `gpu_matlab.sh`. 
-Replace the `<DIR>` with the path to the directory containing the MATLAB script created above. 
-This script will request the desired resrouces, load the MATLAB module, then run the script.
+Now, let's create a Slurm script called `gpu_matlab.sh`.
+Replace the `<DIR>` with the path to the directory containing the MATLAB script created above.
+This script will request the desired resources, load the MATLAB module, then run the script.
 The output of the script will be sent to the file: `gpu_matlab.out`
 
 ```bash
@@ -238,38 +227,41 @@ The output of the script will be sent to the file: `gpu_matlab.out`
 #SBATCH --output gpu_matlab_job.out
 #SBATCH --error gpu_matlab_job.err
 #SBATCH --time 00:05:00
+#SBATCH --partition l40s
 #SBATCH --ntasks 1
-#SBATCH -G 1
+#SBATCH --gres=gpu:l40s:1
 
 cd <DIR>
 
-module load matlab
+module load matlab/R2024b
 matlab -nodisplay -r gpu_matlab > gpu_matlab.out
 ```
 
 
-#### Submit Job to Queue <a name="1.2.4"></a>
+#### Submit Job to Queue <a name="1.2.3"></a>
 
-Now we can submit the job to the scheduler from the xena head node:
+Now we can submit the job to the scheduler from the Easley head node:
 
-PBS script version:
 ```bash
-xena:~$ qsub gpu_matlab.pbs
-```
-
-Slurm script version:
-```bash
-xena:~$ sbatch gpu_matlab.sh
+easley-sn:~$ sbatch gpu_matlab.sh
 ```
 
 View the results:
 ```bash
-xena:~$ cat gpu_matlab.out
+easley-sn:~$ cat gpu_matlab.out
 ```
 
-## Using Multiple GPUs on a single Xena node <a name="2"></a>
+Real output from this exact script, comparing a 5000x5000 `sqrt` on CPU vs. a single L40S GPU:
+```
+sqrt of 5000x5000 matrix on cpu:
+Elapsed time is 13.255715 seconds.
+sqrt of 5000x5000 matrix on gpu:
+Elapsed time is 0.355405 seconds.
+```
 
-Xena contains some nodes with two GPUs.
+## Using Multiple GPUs on a single Easley node <a name="2"></a>
+
+Easley's `l40s` partition has nodes with up to four L40S GPUs.
 MATLAB allows for the utilization of multiple GPUs on a single node in the same way you use multiple CPUs.
 To show how this works, below is an example MATLAB script that will create a logistic map using all available GPU's on the assigned node.
 
@@ -288,8 +280,7 @@ The result is a logistic map figure saved as 'logistic_map.jpg'
 It also contains calls to time the execution of the `parfor` loop.
 
 
-```bash
-
+```matlab
 N = 1000;
 r = gpuArray.linspace(0,4,N);
 
@@ -321,19 +312,14 @@ return
 
 ### Slurm Script <a name="2.2"></a>
 
+Request as many GPUs as you want to use with `--gres=gpu:l40s:<count>`, and match `--cpus-per-task` to that same count, since MATLAB uses a CPU to access each GPU. For two GPUs, ask for two CPUs and two GPUs.
 
-When using the `--partition dualGPU` flag on xena, you must also set `--cpus-per-task 2` and `-G 2` for MATLAB to correctly find and utilize the available GPUs.
-These numbers should match, as MATLAB will use a CPU to access each GPU.
-For this partition, we ask for two CPUs and two GPUs.
-
-Create the following slurm scrpt called `gpu_logistic_map.sh`.
-Replace the `<DIR>` with the path to the directory containing the MATLAB script created above. 
+Create the following slurm script called `gpu_logistic_map.sh`.
+Replace the `<DIR>` with the path to the directory containing the MATLAB script created above.
 This script will ask the scheduler for the proper resources.
-Once the resrouces are allocated, the script will run the MATLAB script from the above step.
+Once the resources are allocated, the script will run the MATLAB script from the above step.
 The MATLAB script will create a .jpg image once it has finished.
 Any output of the MATLAB script is redirected to `gpu_logistic_map.out`.
-
-
 
 ```bash
 #!/bin/bash
@@ -342,27 +328,26 @@ Any output of the MATLAB script is redirected to `gpu_logistic_map.out`.
 #SBATCH --output gpu_logistic_map_job.out
 #SBATCH --error gpu_logistic_map_job.err
 #SBATCH --time 00:10:00
-#SBATCH --partition dualGPU
+#SBATCH --partition l40s
 #SBATCH --ntasks 1
 #SBATCH --cpus-per-task 2
-#SBATCH -G 2
+#SBATCH --gres=gpu:l40s:2
 
 cd <DIR>
 
-module load matlab
+module load matlab/R2024b
 matlab -nodisplay -r gpu_logistic_map > gpu_logistic_map.out
-
 ```
 
 ### Submit Job to Queue <a name="2.3"></a>
 
-Now we can submit the job to the scheduler from the xena head node:
+Now we can submit the job to the scheduler from the Easley head node:
 ```bash
-xena:~$ sbatch gpu_logistic_map.sh
+easley-sn:~$ sbatch gpu_logistic_map.sh
 ```
 View the results:
 ```bash
-xena:~$ cat gpu_logistic_map.out
+easley-sn:~$ cat gpu_logistic_map.out
 ```
 
 You can also view the `logistic_map.jpg` image using your preferred method.
@@ -370,4 +355,4 @@ You can also view the `logistic_map.jpg` image using your preferred method.
 
 ## Using Multiple Nodes with their own GPUs <a name="3"></a>
 
-Coming Soon! (Maybe)
+Coming Soon!


### PR DESCRIPTION
xena's dead, renamed to Using GPUs on Easley with MATLAB.md. old partitions were singleGPU/dualGPU, those don't exist anymore either - easley just has h100 and l40s partitions, request however many gpus you want with --gres=gpu:l40s:N

also dropped the PBS script entirely since it's dead

tested basically the whole thing for real: interactive gpu session, gpuDeviceCount/gpuDeviceTable output (real L40S gpu now instead of the old K40), and both batch scripts actually ran - single gpu one gave a real 13.3s cpu vs 0.36s gpu timing comparison, and the multi-gpu logistic map one ran with 2 gpus and actually produced the jpg