### PR TITLE
Stacks_quickbyte.md

### DIFF
--- a/Stacks_quickbyte.md
+++ b/Stacks_quickbyte.md
@@ -56,7 +56,15 @@ We'll assume you demultiplex your reads before running the pipeline described be
 	mkdir stacks_out
 	mkdir populations_out
 
-The modules you need are stacks, bwa, and samtools. All are available on Conda. `stacks` and `bwa` are also available as modules on Easley, but `samtools` currently is not (it's only a module on Hopper) - use conda for samtools on Easley, or run this on Hopper if you'd rather use modules for all three:
+The modules you need are stacks, bwa, and samtools. All are available on Conda. `stacks` and `bwa` are also available as modules on Easley, but `samtools` currently is not, since it's only a module on Hopper. Use conda for samtools on Easley:
+
+	module load stacks/2.53-ftxb
+	module load bwa/0.7.17-zvtr
+	module load miniconda3/latest
+	conda create -n samtools_env -c bioconda -c conda-forge samtools
+	source activate samtools_env
+
+Or run this on Hopper if you'd rather use modules for all three:
 
 	module load stacks/2.53-ftxb
 	module load bwa/0.7.17-zvtr

--- a/Stacks_quickbyte.md
+++ b/Stacks_quickbyte.md
@@ -56,7 +56,7 @@ We'll assume you demultiplex your reads before running the pipeline described be
 	mkdir stacks_out
 	mkdir populations_out
 
-The modules you need are stacks, bwa, and samtools. All are available on Conda. `stacks` and `bwa` are also available as modules on Easley, but `samtools` currently is not. Use conda for samtools on Easley:
+The modules you need are stacks, bwa, and samtools. All are available on Conda. On Easley, `stacks` and `bwa` are also available as modules, but `samtools` isn't. Use conda to get samtools there:
 
 	module load stacks/2.53-ftxb
 	module load bwa/0.7.17-zvtr
@@ -70,7 +70,7 @@ On Hopper, only `samtools` is available as a module (`samtools/1.16.1-3ojn`). `s
 	conda create -n stacks_env -c bioconda -c conda-forge stacks bwa samtools
 	source activate stacks_env
 
-We'll also set some variables for referring to paths to stuff. We assume that the reference names (ReferenceBaseName):
+We'll also set a few variables for the paths we'll need. We assume the reference name is ReferenceBaseName:
 
 	src=$SLURM_SUBMIT_DIR
 	bwa_ref=$src/ReferenceBaseName

--- a/Stacks_quickbyte.md
+++ b/Stacks_quickbyte.md
@@ -56,7 +56,7 @@ We'll assume you demultiplex your reads before running the pipeline described be
 	mkdir stacks_out
 	mkdir populations_out
 
-The modules you need are stacks, bwa, and samtools. All are available on Conda. `stacks` and `bwa` are also available as modules on Easley, but `samtools` currently is not, since it's only a module on Hopper. Use conda for samtools on Easley:
+The modules you need are stacks, bwa, and samtools. All are available on Conda. `stacks` and `bwa` are also available as modules on Easley, but `samtools` currently is not. Use conda for samtools on Easley:
 
 	module load stacks/2.53-ftxb
 	module load bwa/0.7.17-zvtr
@@ -64,11 +64,11 @@ The modules you need are stacks, bwa, and samtools. All are available on Conda. 
 	conda create -n samtools_env -c bioconda -c conda-forge samtools
 	source activate samtools_env
 
-Or run this on Hopper if you'd rather use modules for all three:
+On Hopper, only `samtools` is available as a module (`samtools/1.16.1-3ojn`). `stacks` has no Hopper module at all, and `bwa` is only reachable through an `intel/20.0.4` prerequisite chain under a different version hash, so conda is the simplest way to get all three tools together there too:
 
-	module load stacks/2.53-ftxb
-	module load bwa/0.7.17-zvtr
-	module load samtools/1.16.1-3ojn
+	module load miniconda3/latest
+	conda create -n stacks_env -c bioconda -c conda-forge stacks bwa samtools
+	source activate stacks_env
 
 We'll also set some variables for referring to paths to stuff. We assume that the reference names (ReferenceBaseName):
 

--- a/Stacks_quickbyte.md
+++ b/Stacks_quickbyte.md
@@ -56,7 +56,13 @@ We'll assume you demultiplex your reads before running the pipeline described be
 	mkdir stacks_out
 	mkdir populations_out
 
-The modules you need are stacks, bwa, and samtools. All are available on Conda. On Easley, `stacks` and `bwa` are also available as modules, but `samtools` isn't. Use conda to get samtools there:
+The modules you need are stacks, bwa, and samtools. All are available on Conda, and conda is the recommended way to get all three on both Easley and Hopper:
+
+	module load miniconda3/latest
+	conda create -n stacks_env -c bioconda -c conda-forge stacks bwa samtools
+	source activate stacks_env
+
+On Easley, `stacks` and `bwa` are also available as modules (`samtools` isn't), but the `stacks/2.53-ftxb` module's `gstacks` currently crashes on real input with a zlib-ng/htslib incompatibility, so conda is the reliable option there for now:
 
 	module load stacks/2.53-ftxb
 	module load bwa/0.7.17-zvtr
@@ -64,11 +70,7 @@ The modules you need are stacks, bwa, and samtools. All are available on Conda. 
 	conda create -n samtools_env -c bioconda -c conda-forge samtools
 	source activate samtools_env
 
-On Hopper, only `samtools` is available as a module (`samtools/1.16.1-3ojn`). `stacks` has no Hopper module at all, and `bwa` is only reachable through an `intel/20.0.4` prerequisite chain under a different version hash, so conda is the simplest way to get all three tools together there too:
-
-	module load miniconda3/latest
-	conda create -n stacks_env -c bioconda -c conda-forge stacks bwa samtools
-	source activate stacks_env
+On Hopper, only `samtools` is available as a module (`samtools/1.16.1-3ojn`). `stacks` has no Hopper module at all, and `bwa` is only reachable through an `intel/20.0.4` prerequisite chain under a different version hash, so conda is the simplest way to get all three tools together there too.
 
 We'll also set a few variables for the paths we'll need. We assume the reference name is ReferenceBaseName:
 

--- a/Stacks_quickbyte.md
+++ b/Stacks_quickbyte.md
@@ -1,6 +1,6 @@
 # Running Stacks on CARC #
 
-Stacks is a common and [well documented](https://catchenlab.life.illinois.edu/stacks/) pipeline for processing RADseq data. RADseq data is a method of reduced representation genomic sequencing, where genomic DNA is cut up with restriction enzymes, which are then targeted by sequencing adapters. This allows a researcher to get thousands of loci randomly scattered across the genome, which can be sequenced at moderate depths for low prices. This is sufficient for many population genomic analyses, such as tests of population structure, phylogenetics, gene flow, and even coarse attempts to locate regions of the genome that are under selection. Stacks can be run with or without a reference genome, but using a reference genome is reccomended for improved accuracy.
+Stacks is a common and [well documented](https://catchenlab.life.illinois.edu/stacks/) pipeline for processing RADseq data. RADseq data is a method of reduced representation genomic sequencing, where genomic DNA is cut up with restriction enzymes, which are then targeted by sequencing adapters. This allows a researcher to get thousands of loci randomly scattered across the genome, which can be sequenced at moderate depths for low prices. This is sufficient for many population genomic analyses, such as tests of population structure, phylogenetics, gene flow, and even coarse attempts to locate regions of the genome that are under selection. Stacks can be run with or without a reference genome, but using a reference genome is recommended for improved accuracy.
 
 Stacks can easily be run on Easley with installed modules, and here we outline how with some simple "quality of life" adjustments and tips. We'll be focused on the reference based method, as the non-reference-based is sufficiently run through a driver script provided by the developers of Stacks (denovo_map.pl). We'll quickly mention it at the end. This can often be run on a single node on Easley, as the only intense step tends to be alignment, which is quick due to the small size of RADseq data. For example, a dataset of ~90 bird individuals with an average of 1 million reads/sample took four hours on one node. Organisms with larger genomes will take more time and memory.
 
@@ -15,7 +15,7 @@ Before you get started, you'll need a list of sample names to run bwa convenient
 	M_americana_NM_MSBBIRD39487
 	......
 
-Then, key to many pieces of population genetics software, Stacks needs a population map (popmap) for calculating metrics like F<sub>st</sub> and genetic dviersity. It will also allow the creation of certain imput files. It is simply a tab delimited file with one line per individual, with the first column representing the sample name and the second its population. Note that reduced versions of the popmaps can be made for running _gstacks_ and _populations_ for only a subset of your dataset.
+Then, key to many pieces of population genetics software, Stacks needs a population map (popmap) for calculating metrics like F<sub>st</sub> and genetic diversity. It will also allow the creation of certain input files. It is simply a tab delimited file with one line per individual, with the first column representing the sample name and the second its population. Note that reduced versions of the popmaps can be made for running _gstacks_ and _populations_ for only a subset of your dataset.
 
 	<SAMPLE NAME>\t<SAMPLE POPULATION>
 	M_americana_Florida_MSBBIRD49539	EastBlackScoter
@@ -24,7 +24,7 @@ Then, key to many pieces of population genetics software, Stacks needs a populat
 
 ### Demultiplexing with process_radtags ###
 
-Demultiplexing with Stacks is comparatively easy. You just need a file of barcode information (we'll call it BARCODES.file) and your raw, multiplexed reads. The barcode information file can be paired or unapired, and should look like:
+Demultiplexing with Stacks is comparatively easy. You just need a file of barcode information (we'll call it BARCODES.file) and your raw, multiplexed reads. The barcode information file can be paired or unpaired, and should look like:
 
 	<BARCODE1>\t<BARCODE2>\t<SAMPLE NAME>
 	ATGCAT	GTACGT	M_americana_Florida_MSBBIRD49539
@@ -36,7 +36,7 @@ Here is how to run it, assuming you are dealing with paired end reads, gzipped f
 	process_radtags -p /path/to/MULTIPLEXED_READS/ -b /path/to/BARCODES.file -o /path/to/raw_reads/ \
 		-i gzfastq -e ndeI -c -q -r -E phred33 
 
-The command is different for single end reads. You must specify each fastq input indiviually with the -f flag, as shown below. The rest is the same:
+The command is different for single end reads. You must specify each fastq input individually with the -f flag, as shown below. The rest is the same:
 
 	process_radtags -f /path/to/MULTIPLEXED_READS/RAW_READS_01.fastq.gz -b /path/to/BARCODES.file -o /path/to/raw_reads/ \
 		-i gzfastq -e ndeI -c -q -r -E phred33
@@ -56,13 +56,13 @@ We'll assume you demultiplex your reads before running the pipeline described be
 	mkdir stacks_out
 	mkdir populations_out
 
-The modules you need are stacks, bwa, and samtools. All are availible on Conda. `stacks` and `bwa` are also available as modules on Easley, but `samtools` currently is not (it's only a module on Hopper) - use conda for samtools on Easley, or run this on Hopper if you'd rather use modules for all three:
+The modules you need are stacks, bwa, and samtools. All are available on Conda. `stacks` and `bwa` are also available as modules on Easley, but `samtools` currently is not (it's only a module on Hopper) - use conda for samtools on Easley, or run this on Hopper if you'd rather use modules for all three:
 
 	module load stacks/2.53-ftxb
 	module load bwa/0.7.17-zvtr
 	module load samtools/1.16.1-3ojn
 
-We'll also set some variables for refering to paths to stuff. We assume that the reference names (ReferenceBaseName):
+We'll also set some variables for referring to paths to stuff. We assume that the reference names (ReferenceBaseName):
 
 	src=$SLURM_SUBMIT_DIR
 	bwa_ref=$src/ReferenceBaseName
@@ -72,7 +72,7 @@ Next, we need to index our reference:
 
 	bwa index -p $bwa_ref $bwa_ref.fa
 
-This is the big step, which uses the Burroughs-Wheeler Aligner to align our reads to our reference. Note that this should be able to be done using pipes, but I've had issues with that, so we just remove the files at the end of each loop.
+This is the big step, which uses the Burrows-Wheeler Aligner to align our reads to our reference. Note that this should be able to be done using pipes, but I've had issues with that, so we just remove the files at the end of each loop.
 
 	while read indiv
 	do
@@ -99,7 +99,7 @@ Finally, we run populations! This specific command will give us a 75% complete m
 	
 A quick note, if you want input for RAxML or similar phylogenetic programs, you can get a interleaved phylip file by making a popmap file with each individual having its own population and specifying you want a phylip output. Please note that this is strict phylip format, meaning you want a maximum of 9 letters in your "population" column of the popmap (10 works, but will cause errors when input to certain programs). Also, this assumes you have a directory "populations_individual":
 
-	populations -P $src/stacks_out/ -M $src/popmap_individual -O $src/popualtions_individual/ \
+	populations -P $src/stacks_out/ -M $src/popmap_individual -O $src/populations_individual/ \
 		-R .75 --phylip-var-all -t $threads
 
 Learn more about the outputs and options for populations [on the Stacks website](https://catchenlab.life.illinois.edu/stacks/comp/populations.php). Also, as mentioned above, you can easily subset your data by changing the popmap used in gstacks and populations, as each sample has alignments performed separately.

--- a/Stacks_quickbyte.md
+++ b/Stacks_quickbyte.md
@@ -2,7 +2,7 @@
 
 Stacks is a common and [well documented](https://catchenlab.life.illinois.edu/stacks/) pipeline for processing RADseq data. RADseq data is a method of reduced representation genomic sequencing, where genomic DNA is cut up with restriction enzymes, which are then targeted by sequencing adapters. This allows a researcher to get thousands of loci randomly scattered across the genome, which can be sequenced at moderate depths for low prices. This is sufficient for many population genomic analyses, such as tests of population structure, phylogenetics, gene flow, and even coarse attempts to locate regions of the genome that are under selection. Stacks can be run with or without a reference genome, but using a reference genome is reccomended for improved accuracy.
 
-Stacks can easily be run on Wheeler with installed modules, and here we outline how with some simple "quality of life" adjustments and tips. We'll be focused on the reference based method, as the non-reference-based is sufficiently run through a driver script provided by the developers of Stacks (denovo_map.pl). We'll quickly mention it at the end. This can often be run on a single node on Wheeler, as the only intense step tends to be alignment, which is quick due to the small size of RADseq data. For example, a dataset of ~90 bird individuals with an average of 1 million reads/sample took four hours on one node. Organisms with larger genomes will take more time and memory.
+Stacks can easily be run on Easley with installed modules, and here we outline how with some simple "quality of life" adjustments and tips. We'll be focused on the reference based method, as the non-reference-based is sufficiently run through a driver script provided by the developers of Stacks (denovo_map.pl). We'll quickly mention it at the end. This can often be run on a single node on Easley, as the only intense step tends to be alignment, which is quick due to the small size of RADseq data. For example, a dataset of ~90 bird individuals with an average of 1 million reads/sample took four hours on one node. Organisms with larger genomes will take more time and memory.
 
 ## Preliminaries ##
 
@@ -56,15 +56,15 @@ We'll assume you demultiplex your reads before running the pipeline described be
 	mkdir stacks_out
 	mkdir populations_out
 
-The modules you need are stacks, bwa, and samtools. All are availible on Conda, but you will almost certainly be running this on Wheeler (low resource use), which has recent versions of all three installed:
+The modules you need are stacks, bwa, and samtools. All are availible on Conda. `stacks` and `bwa` are also available as modules on Easley, but `samtools` currently is not (it's only a module on Hopper) - use conda for samtools on Easley, or run this on Hopper if you'd rather use modules for all three:
 
-	module load stacks-2.41-gcc-7.4.0-7r6auk7
-	module load bwa-0.7.17-intel-18.0.2-7jvpfu2
-	module load samtools-1.10-gcc-9.3.0-python3-ikifznw
+	module load stacks/2.53-ftxb
+	module load bwa/0.7.17-zvtr
+	module load samtools/1.16.1-3ojn
 
 We'll also set some variables for refering to paths to stuff. We assume that the reference names (ReferenceBaseName):
 
-	src=$PBS_O_WORKDIR
+	src=$SLURM_SUBMIT_DIR
 	bwa_ref=$src/ReferenceBaseName
 	threads=[number of threads]
 
@@ -111,8 +111,8 @@ This is a lot simpler, but is generally considered less robust than a reference-
 First, you only need the Stacks module and one new directory (assumes reads are in "raw_reads").
 
 	mkdir stacks_denovo
-	module load stacks-2.41-gcc-7.4.0-7r6auk7
-	src=$PBS_O_WORKDIR
+	module load stacks/2.53-ftxb
+	src=$SLURM_SUBMIT_DIR
 	threads=[number of threads]
 
 Then you just run a single line!


### PR DESCRIPTION
wheeler dead, bumped stacks/bwa/samtools module versions. samtools isn't a module on easley anymore (only hopper), noted that and pointed to conda as the easley option

also found stacks has no hopper module at all (not even under a different hash) and bwa's hopper module needs an intel/20.0.4 prereq under a different name - fixed by switching the "use modules on hopper" alternative to conda for all three there too, tested and confirmed working (populations/bwa/samtools all functional in one conda env on hopper).

heads up on something found during a later retest that's out of my ability to fix: gstacks itself (from the easley `stacks/2.53-ftxb` module) crashes on any real input with a zlib-ng/htslib assertion failure:

```
gstacks: bgzf.c:347: bgzf_hopen: Assertion `compressBound(BGZF_BLOCK_SIZE) < BGZF_MAX_BLOCK_SIZE' failed.
```

reproduced this with multiple thread counts (-t 1, -t 2), so it's not a concurrency fluke - the module itself looks broken on easley. the conda-based stacks install (via `stacks_env` or similar) is unaffected and works fine, so recommend using conda for stacks on easley until CARC rebuilds/fixes that module. not something a doc edit can resolve.