### PR TITLE
SimCov.md

### DIFF
--- a/SimCov.md
+++ b/SimCov.md
@@ -1,4 +1,4 @@
-This tutorial contains instructions for compiling and running the SimCov immunology model on the Wheeler cluster.
+This tutorial contains instructions for compiling and running the SimCov immunology model on the Hopper cluster.
 
 ## Download the SimCov Source Code from GitHub
 
@@ -12,13 +12,14 @@ git clone --recurse-submodules https://github.com/AdaptiveComputationLab/simcov.
 ```
 
 ## Build SimCov from Source
-Load Wheeler modules and set UPCXX variables (NOTE: modules subject to change use 'module spider' to find availability):
+Load Hopper modules and set UPCXX variables (NOTE: modules subject to change use 'module spider' to find availability). UPC++ is currently only available as a module on Hopper, not Easley, so this needs to run on Hopper:
 ```
 export UPCXX_THREADMODE=seq
 export UPCXX_CODEMODE=opt
-module load gcc/11.2.0-otgt
-module load cmake/3.22.2-c2dw
-module load upcxx/2021.9.0-r4of
+module load gcc/8.5.0-lpgx
+module load cmake/3.31.6-qm2s
+module load upcxx/2022.3.0-yrwd
+export CXX=$(dirname $(dirname $(which upcxx-meta)))/openmpi-3.1.6-psvczpcxkv3y5vn7btswoy4kmxr5aexh/bin/mpic++
 ```
 Run the build script:
 ```
@@ -29,29 +30,29 @@ cd simcov
 The config files are in ~/simcov and end with ".config". You can edit them with a text editor.
 
 ## Submit a SimCov Job 
-A wheeler PBS script is provided for you. We have submitted the script below to the simcov developers - so hopefully by the time you pull simcov the code below will already be in the wheeler_simcov_run.pbs. If not update the script to contain the following: 
- 
-This PBS submission script will run simcov on a compute node using covid_default.config:
+This Slurm submission script will run simcov on a compute node using covid_default.config:
 ```
 #!/bin/bash
 
-#PBS -q normal
-#PBS -l nodes=2:ppn=8
-#PBS -l walltime=01:00:00
-#PBS -N simcov_test
-#PBS -j oe
+#SBATCH --job-name simcov_test
+#SBATCH --partition general
+#SBATCH --nodes 2
+#SBATCH --ntasks-per-node 8
+#SBATCH --time 01:00:00
+#SBATCH --output simcov_test.out
+#SBATCH --error simcov_test.err
 
-module load gcc/11.2.0-otgt
-module load upcxx/2021.9.0-r4of
-module load cmake/3.22.2-c2dw
+module load gcc/8.5.0-lpgx
+module load upcxx/2022.3.0-yrwd
+module load cmake/3.31.6-qm2s
 
-cd $PBS_O_WORKDIR
+cd $SLURM_SUBMIT_DIR
 
-upcxx-run -n $PBS_NP -N $PBS_NUM_NODES -- install/bin/simcov --config=covid_default.config --output=results
+upcxx-run -n $SLURM_NTASKS -N $SLURM_NNODES -- install/bin/simcov --config=covid_default.config --output=results
 ``` 
 To run simcov on a compute node enter
 ```
-qsub wheeler_simcov_run.pbs
+sbatch hopper_simcov_run.sh
 ```
 
 Outputs will be in a results folder by default

--- a/SimCov.md
+++ b/SimCov.md
@@ -19,7 +19,8 @@ export UPCXX_CODEMODE=opt
 module load gcc/8.5.0-lpgx
 module load cmake/3.31.6-qm2s
 module load upcxx/2022.3.0-yrwd
-export CXX=$(dirname $(dirname $(which upcxx-meta)))/openmpi-3.1.6-psvczpcxkv3y5vn7btswoy4kmxr5aexh/bin/mpic++
+module load openmpi/3.1.6-qpl3
+export CXX=$(which mpic++)
 ```
 Run the build script:
 ```


### PR DESCRIPTION
wheeler's dead. upcxx (needed for this) isn't a module on easley at all, only hopper, so moved the whole tutorial to hopper and bumped gcc/cmake/upcxx to hopper's latest versions. pbs script converted to slurm

actually tried building this for real and hit a real problem: the newer upcxx/2022.3.0 module's gasnet backend fails to link with 'undefined reference to hwloc_type_sscanf' - looks like simcov's own build script/cmake setup doesn't explicitly link hwloc against this upcxx version. tried matching the exact compiler upcxx was built with (mpic++) and loading an hwloc module directly, neither fixed it. this looks like an upstream simcov/gasnet build issue, not something fixable by picking different carc modules - flagging it here since i can't verify the full build+run actually completes end to end right now

update from a later retest: found and fixed a real, separate bug in the doc itself - the hardcoded CXX path (`.../openmpi-3.1.6-psvczpcxkv3y5vn7btswoy4kmxr5aexh/bin/mpic++`) doesn't exist anymore, the current upcxx module doesn't ship its own bundled openmpi at all. swapped it for loading the real `openmpi/3.1.6-qpl3` module and using its `mpic++` directly. confirmed this genuinely helps - the build now gets to 81-83% complete instead of failing immediately at cmake's configure step.

it still doesn't complete though, hitting the same pre-existing hwloc issue described above, just much further into the build now. exact verbatim error at the point it fails:

```
/opt/spack/opt/spack/linux-rocky8-skylake_avx512/gcc-8.5.0/upcxx-2022.3.0-yrwdm7cajqjkmsmxdfwehsa65tz6laec/gasnet.opt/lib/libgasnet-ibv-seq.a(gasnet_hwloc.o): In function `gasneti_getenv_hwloc_withdefault':
gasnet_hwloc.c:(.text+0x2ad): undefined reference to `hwloc_type_sscanf'
/opt/spack/opt/spack/linux-rocky8-skylake_avx512/gcc-8.5.0/upcxx-2022.3.0-yrwdm7cajqjkmsmxdfwehsa65tz6laec/gasnet.opt/lib/libgasnet-ibv-seq.a(gasnet_hwloc.o): In function `gasneti_getenv_hwloc_withdefault.cold.2':
gasnet_hwloc.c:(.text.unlikely+0x27): undefined reference to `hwloc_type_sscanf'
collect2: error: ld returned 1 exit status
make: *** [Makefile:136: all] Error 2
```

still a genuine upstream gasnet/hwloc ABI mismatch, not something fixable from the doc side - flagging for whoever picks this up next, at least they'll get much further before hitting it now.