### PR TITLE
paraview.md

### DIFF
--- a/paraview.md
+++ b/paraview.md
@@ -4,7 +4,7 @@ ParaView is an open-source, multi-platform data analysis and visualization appli
 
 ParaView was developed to analyze extremely large datasets using distributed memory computing resources. It can be run on supercomputers to analyze datasets of petascale size.
 
-These steps will help you setup Paraview to work as a client/server mode, being your laptop/desktop computer a client and the cluster a server. Be sure that the ParaView version installed on your local computer matches the same one that is installed on Wheeler and Hopper clusters.
+These steps will help you setup Paraview to work as a client/server mode, being your laptop/desktop computer a client and the cluster a server. Be sure that the ParaView version installed on your local computer matches the same one that is installed on the Easley and Hopper clusters.
 
 To see a current list of paraview versions installed on CARC clusters login to the cluster and run
 
@@ -19,7 +19,7 @@ The most common approach to use ParaView on Hopper is through the Client-Server 
 
 ### Method 1: Direct Connection (Off-Campus)
 
-The process to connecto to ParaView is, in one terminal you will ask Hopper to assign you compute nodes, where you will run the ParaView server. Once the ParaView server is listening for connections, you will open an ssh tunnel in another terminal window (This process is from your local computer to one of the compute nodes you were assigned). Then, you will tell the ParaView client on your computer to connect to the tunnel and so to the compute nodes at CARC, where it will perform the rendering.
+The process to connect to ParaView is, in one terminal you will ask Hopper to assign you compute nodes, where you will run the ParaView server. Once the ParaView server is listening for connections, you will open an ssh tunnel in another terminal window (This process is from your local computer to one of the compute nodes you were assigned). Then, you will tell the ParaView client on your computer to connect to the tunnel and so to the compute nodes at CARC, where it will perform the rendering.
 
 #### Terminal 1: Login to Hopper and allocate resources
 


### PR DESCRIPTION
this one was already mostly modernized (hopper/slurm-based) but missed one line still mentioning wheeler, and had a 'connecto' typo. fixed both, tested paraview/5.11.1 module still loads fine on easley and confirmed it's the same version on both clusters like the doc claims