### PR TITLE
submitting_jobs.md

### DIFF
--- a/submitting_jobs.md
+++ b/submitting_jobs.md
@@ -1,51 +1,89 @@
 # Submitting jobs
-There are two ways you can run your jobs, namely submitting a Slurm script and running a job interactively. Either way, jobs are submitted to CARC by the command `sbatch`. For more information on available options type `man sbatch`
+
+There are two ways you can run your jobs, namely submitting a Slurm script and running a job interactively. Either way, jobs are submitted to CARC by the command `sbatch`. For more information on available options type `man sbatch`.
+
 ### Submitting the Slurm Script to the Batch Scheduler
-In order to run our simple Slurm script, we will need to submit it to the batch scheduler using the command `sbatch` followed by the name of the script we would like to run. For more information please see our page on writing a [Slurm batch script](https://github.com/UNM-CARC/QuickBytes/blob/master/pbs_scripts2.md).
-In the following example, we submit our simple `hello.sbatch` script to the batch scheduler using `sbatch`. Note that it returns the job identifier when the job is successfully submitted. You can use this job identifier to query the status of your job from your shell.  
+
+In order to run our simple Slurm script, we will need to submit it to the batch scheduler using the command `sbatch` followed by the name of the script we would like to run. For more information please see our page on [writing a Slurm batch script](https://github.com/UNM-CARC/QuickBytes/blob/master/submitting_sbatch_jobs.md).
+
+In the following example, we submit our simple `hello.sbatch` script to the batch scheduler using `sbatch`. Note that it returns the job identifier when the job is successfully submitted. You can use this job identifier to query the status of your job from your shell.
 For example:
 
 ```bash
 sbatch hello.sbatch
-Submitted batch job 156452
 ```
+
+```
+Submitted batch job 1035461
+```
+
 ### Interactive Slurm Jobs
-Normally a job is submitted for execution on a cluster or supercomputer using the command `sbatch script.sbatch`. CARC recommends that all jobs are submitted this way as job submission fails if there are errors in resources requested. However, at times, such as when debugging, it can be useful to run a job interactively. To run a job in this way type `salloc` followed by resources requested, and the batch manager will log you into a node where you can directly run your code.  
-For example, here is the output from an interactive session running our simple `helloworld_paralell.sbatch` script:
+
+Normally a job is submitted for execution on a cluster or supercomputer using the command `sbatch script.sbatch`. CARC recommends that all jobs are submitted this way as job submission fails if there are errors in resources requested. However, at times, such as when debugging, it can be useful to run a job interactively. To run a job in this way type `salloc` followed by resources requested, and the batch manager will log you into a node where you can directly run your code.
+
+Here's our simple `helloworld_parallel.sbatch` script, which prints a hello message from every task it's given:
+
+```bash
+export THIS_HOST=$(hostname)
+echo "Job $SLURM_JOB_ID running on $THIS_HOST"
+echo "Hello World from host $THIS_HOST"
+```
+
+To actually run it across multiple tasks, it needs to be launched with `mpirun`. Just running it with plain `bash` would only ever execute it once, regardless of how many tasks you requested with `salloc`.
+
+Here's an interactive session running it across all 8 tasks of a node:
 
 ```bash
 salloc --nodes=1 --ntasks=8 --time=00:05:00
-
-salloc: Granted job allocation 156469
-salloc: Nodes easley004 are ready for job
-
-module load openmpi
-
-bash  helloworld_parallel.sbatch
-Job 156469 running on easley004
-Hello World from host easley004
-Hello World from host easley004
-Hello World from host easley004
-Hello World from host easley004
-Hello World from host easley004
-Hello World from host easley004
-Hello World from host easley004
-Hello World from host easley004
 ```
+
+```
+salloc: Granted job allocation 1035500
+salloc: Nodes easley031 are ready for job
+```
+
+```bash
+module load openmpi
+mpirun -np 8 bash $PWD/helloworld_parallel.sbatch
+```
+
+```
+Job 1035500 running on easley031
+Hello World from host easley031
+Job 1035500 running on easley031
+Hello World from host easley031
+Job 1035500 running on easley031
+Hello World from host easley031
+Job 1035500 running on easley031
+Hello World from host easley031
+Job 1035500 running on easley031
+Hello World from host easley031
+Job 1035500 running on easley031
+Hello World from host easley031
+Job 1035500 running on easley031
+Hello World from host easley031
+Job 1035500 running on easley031
+Hello World from host easley031
+```
+
 Three commands were executed here. The first,
 
 ```bash
 salloc --nodes=1 --ntasks=8 --time=00:05:00
 ```
-asked the batch manager to provide one node of easley with all 8 of that node’s cores for use. It is good practice to request all available processors on a node to avoid multiple users being assigned to the same node. The walltime was specified as 5 minutes, since this was a simple code that would execute quickly. The second command, 
+
+asked the batch manager to provide one node of easley with all 8 of that node's cores for use. It is good practice to request all available processors on a node to avoid multiple users being assigned to the same node. The walltime was specified as 5 minutes, since this was a simple code that would execute quickly. The second command,
 
 ```bash
 module load openmpi
 ```
-loaded the openMPI software module to parallelize our script across all 8 processors; this ensures that the necessary MPI libraries would be available during execution. The third command, 
+
+loaded the openMPI software module, giving us the MPI libraries and the `mpirun` launcher needed to actually run the script across all 8 tasks. The third command,
 
 ```bash
-bash  helloworld_parallel.sbatch
+mpirun -np 8 bash $PWD/helloworld_parallel.sbatch
 ```
-ran the commands found within our `helloworld_parallel.sbatch` script.
 
+ran the `helloworld_parallel.sbatch` script across all 8 requested tasks, using an absolute path since `mpirun` doesn't necessarily preserve your current directory across every task.
+
+*This quickbyte was validated on 7/30/2026*


### PR DESCRIPTION
found a real bug testing this one. the interactive section claims running `bash helloworld_parallel.sbatch` under an 8-task salloc allocation prints "Hello World" 8 times - it doesn't, plain bash only ever runs a script once no matter how many tasks you asked for. confirmed by actually testing it (only got 1 line), then fixed it to use `mpirun -np 8` instead and got the real 8-line output.

also fixed the dead link to `pbs_scripts2.md` (doesn't exist, never has as far as I can tell) - pointed it at `submitting_sbatch_jobs.md` instead which actually covers writing a slurm script. added the actual `helloworld_parallel.sbatch` script content too since the doc referenced it without ever showing it. split the combined command+output code blocks into separate ones to match the rest of the repo's formatting, and used real job IDs/hostnames from testing instead of the placeholder ones.

heads up: this file isn't linked from README at all, and its content pretty heavily overlaps with `submitting_sbatch_jobs.md` (which already covers hello world + sbatch/salloc more thoroughly). didn't touch that structural question, just fixed what was actually broken in the file as it exists.