### PR TITLE
submitting_sbatch_jobs.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Quickbytes are tutorials designed to help CARC users.
       * [SSH keys and Config file](https://github.com/UNM-CARC/QuickBytes/blob/table-of-contents-readme/ssh_keygen_config.md)
       * [Transferring data](https://github.com/UNM-CARC/QuickBytes/blob/master/transfer_data.md)
       * [PBS/TORQUE](https://github.com/UNM-CARC/QuickBytes/blob/master/pbs-torque.md)
-      * [Submitting Slurm Scripts with SBatch](https://github.com/UNM-CARC/QuickBytes/blob/master/submitting_sbtach_jobs.md)
+      * [Submitting Slurm Scripts with SBatch](https://github.com/UNM-CARC/QuickBytes/blob/master/submitting_sbatch_jobs.md)
       * [Check running jobs](https://github.com/UNM-CARC/QuickBytes/blob/master/checking_on_running_jobs.md) 
       * [Managing modules](https://github.com/UNM-CARC/QuickBytes/blob/master/module_management.md)
       * [Intro to Slurm](https://github.com/UNM-CARC/QuickBytes/blob/master/Intro_to_slurm.md)

--- a/submitting_sbatch_jobs.md
+++ b/submitting_sbatch_jobs.md
@@ -176,26 +176,36 @@ salloc: Granted job allocation 156469
 salloc: Nodes easley004 are ready for job
 ```
 
-Once on the node, load your modules and run your script normally:
+Once on the node, load your modules and run your script. Note that plain `bash helloworld_parallel.sh` would only ever run the script once, regardless of how many tasks you requested — to actually run it across all 8 tasks you need to launch it with `mpirun`:
 
 ```bash
 module load openmpi
-bash helloworld_parallel.sh
+mpirun -np 8 bash $PWD/helloworld_parallel.sh
 ```
 
 ```
-Hello World from host easley004
-Hello World from host easley004
-Hello World from host easley004
-Hello World from host easley004
-Hello World from host easley004
-Hello World from host easley004
-Hello World from host easley004
-Hello World from host easley004
+Job 1035500 running on easley031
+Hello World from host easley031
+Job 1035500 running on easley031
+Hello World from host easley031
+Job 1035500 running on easley031
+Hello World from host easley031
+Job 1035500 running on easley031
+Hello World from host easley031
+Job 1035500 running on easley031
+Hello World from host easley031
+Job 1035500 running on easley031
+Hello World from host easley031
+Job 1035500 running on easley031
+Hello World from host easley031
+Job 1035500 running on easley031
+Hello World from host easley031
 ```
+
+`helloworld_parallel.sh` here is the same kind of script as `hello.sh` above, printing a hello message with `$SLURM_JOB_ID` and the hostname. An absolute path (`$PWD/helloworld_parallel.sh`) is used since `mpirun` doesn't necessarily preserve your current directory across every task.
 
 When you are finished, type `exit` to release the node back to the pool.
 
 > **Note:** CARC recommends submitting jobs via `sbatch` wherever possible, as job submission will catch errors in resource requests before the job runs. Reserve interactive sessions for debugging and development.
 
-*This quickbyte was validated on 6/17/2026*
+*This quickbyte was validated on 7/30/2026*


### PR DESCRIPTION
tested all 3 example scripts (hello.sh, multiprocessor.sh, multinode.sh) for real with sbatch, all work as documented.

found the same real bug I found in submitting_jobs.md, but in this file's own "Interactive Jobs" section: it claims running `bash helloworld_parallel.sh` under an 8-task salloc prints "Hello World" 8 times. tested it, it doesn't - plain bash only runs the script once no matter how many tasks you requested. fixed to use `mpirun -np 8` and got the real 8-line output.

also fixed a typo in the README link to this file - it was pointing at "submitting_sbtach_jobs.md" (missing the 'a'), a dead link since the actual filename is spelled correctly. that's actually how I ended up looking at this file this closely.