### PR TITLE
julia_with_jupyterhub.md

### DIFF
--- a/julia_with_jupyterhub.md
+++ b/julia_with_jupyterhub.md
@@ -35,3 +35,5 @@ Julia should now appear as an option in JupyterHub.
 1. Start a JupyterHub job.
 2. In the upper right portion of the screen, click on the 'new' drop-down menu.
 3. Select the Julia option.
+
+*This quickbyte was validated on 7/30/2026*


### PR DESCRIPTION
tested the whole thing for real - module load julia resolves fine (julia/1.8.5 default), and the Pkg.add("IJulia")/Pkg.build("IJulia") workflow actually registers a julia-1.8 jupyter kernel spec. no bugs, just added a validation date.