### PR TITLE
learning_linux.md

### DIFF
--- a/learning_linux.md
+++ b/learning_linux.md
@@ -1,6 +1,6 @@
 # Linux
 
-All CARC systems run Linux as their operating system and are interacted with in a command-line interface (CLI) as opposed to a graphical user interface (GUI) where you can point at and click on things with a mouse.In order to effectively navigate and efficiently utilize CARC systems we recommend you become familiar with basic Linux commands and navigation in a CLI.
+All CARC systems run Linux as their operating system and are interacted with in a command-line interface (CLI) as opposed to a graphical user interface (GUI) where you can point at and click on things with a mouse. In order to effectively navigate and efficiently utilize CARC systems we recommend you become familiar with basic Linux commands and navigation in a CLI.
 Although the command line environment can look intimidating at first, you will soon learn that because Linux/Unix were written by scientists for scientists, these tools are extremely powerful and you can become more productive using them than you thought possible. There are many resources freely available for learning this material, and since they have been written better than CARC could hope to do, we will now simply direct you to some of our favorite learning resources.
 
 ### Learning Linux
@@ -14,7 +14,7 @@ Below are some great resources for learning the basics of operating in a Linux C
 Once you are confident operating within Linux you may want to dabble in writing some of your own programs. One of the great things about computers is that we can automate them to perform tedious and menial tasks that would take us hours or days to complete, and a computer can do it almost instantaneously and without error. Below are resources for learning some of the more common programming languages.
 
 1. [Python](https://www.python.org/) \- Python is one of the most popular languages for scientific computing and is a great skill to learn, even if you are just trying to debug someone else's code. [Rosalind](http://rosalind.info/problems/locations/) has some really great lessons focused on solving actual problems in order to learn to program in python. Lessons range in difficulty from very simple to rather advanced.
-2. [Julia](https://julialang.org/) \- Julie is another powerful programing language popular for scientific computing. 
+2. [Julia](https://julialang.org/) \- Julia is another powerful programming language popular for scientific computing. 
 	* [Learn X in Y Minutes](https://learnxinyminutes.com/docs/julia/)
 	* [Julia by Example](http://samuelcolvin.github.io/JuliaByExample/)
 3. [Go](https://golang.org/) \- Go is a programming language developed by Google. 
@@ -22,3 +22,5 @@ Once you are confident operating within Linux you may want to dabble in writing 
 	* [Go by example](https://gobyexample.com/)
 
 In addition to these more modern languages, a decent foundation in the classics like Perl, C, C++, and Fortran can be beneficial to learn as a lot of software, both old and current, are written in these languages, and a basic understanding of how to read the code can help when troubleshooting issues.
+
+*This quickbyte was validated on 7/30/2026*


### PR DESCRIPTION
just a link/typo pass, no code here to test. fixed "Julie is another powerful programing language" -> "Julia is another powerful programming language" (wrong name for the language plus a typo), and a missing space after a period. checked every external link, all resolve fine except linuxjourney.com which 403s - pretty sure that's just cloudflare bot-blocking curl since it's a well known real site, not an actual dead link, so left it as is.