### PR TITLE
MATLAB Deep Learning on Xena.md

### DIFF
--- a/MATLAB Deep Learning on Easley.md
+++ b/MATLAB Deep Learning on Easley.md
@@ -1,14 +1,14 @@
-#  MATLAB Deep Learning on Xena
+#  MATLAB Deep Learning on Easley
 
 MATLAB has great tools for deep learning and convolutional neural networks (CNNs).
-These tools can make use of GPUs, which are available for use on the Xena cluster.
+These tools can make use of GPUs, which are available for use on the Easley cluster.
 This Quickbytes tutorial will mimic the official Mathworks tutorial on using deep learning for JPEG Image Deblocking.
 To see that tutorial, follow this [link.](https://www.mathworks.com/help/images/jpeg-image-deblocking-using-deep-learning.html#JPEGImageDeblockingUsingDeepLearningExample-2 "MathWorks Deep Learning Tutorial")
 
 Before we begin, create a directory named 'deepLearningExample' from within your home directory.
 ```bash
-xena:~$ cd ~
-xena:~$ mkdir deepLearningExample
+easley:~$ cd ~
+easley:~$ mkdir deepLearningExample
 ```
 
 ## Table of Contents
@@ -36,7 +36,7 @@ xena:~$ mkdir deepLearningExample
 
 ## Train CNN Interactively <a name="1"></a>
 It is possible to train the the example CNN in an interactive MATLAB session and track the progress.
-This requires X11 fowarding.
+This requires X11 forwarding.
 For a full guide on how to do that, please view our [Quickbytes youtube tutorial.](https://www.youtube.com/watch?v=-5ic9JWHuqI&t=224s&ab_channel=UNMCARC "Quickbytes X11 Forwarding Tutorial").
 Please note that you should not fully train a CNN interactively as the plotting requires large amounts of memory.
 It is alright to use the interactive plotting to verify that a model is training.
@@ -44,26 +44,26 @@ In order to fully train a model, please schedule a job using a slurm script and 
 
 ### Open MATLAB <a name="1.1"></a>
 
-It is highly reccommended to use the dualGPU partition and request two GPUs.
-The commands below will show you how to use both the single and dual GPU partitions.
+Easley's GPU partitions are `h100` and `l40s`. Each `h100` node has 2 GPUs available, so it's recommended to use the `h100` partition and request both GPUs.
+The commands below will show you how to use both a single GPU and both GPUs on a node.
 
-Once logged into Xena with X11 fowarding, you can begin an interactive job on a compute node.
+Once logged into Easley with X11 forwarding, you can begin an interactive job on a compute node.
 ```bash
-xena:~$ srun --partition singleGPU --x11 --mem 0 --ntasks 1 --cpus-per-task 16 -G 1 --pty bash
+easley:~$ srun --partition h100 --x11 --mem 0 --ntasks 1 --cpus-per-task 16 --gres=gpu:h100:1 --pty bash
 ```
 
 This requests a single node and gpu with X11 forwarding.
 
 To use a machine with two gpus, use this command instead:
 ```bash
-xena:~$ srun --partition dualGPU --x11 --mem 0 --ntasks 1 --cpus-per-task 16 -G 2 --pty bash
+easley:~$ srun --partition h100 --x11 --mem 0 --ntasks 1 --cpus-per-task 16 --gres=gpu:h100:2 --pty bash
 ```
 
 Once you are assigned a compute node, cd into our new directory, then start an interactive session of MATLAB:
 ```bash
-xena-01:~$ cd deepLearningExample/
-xena-01:~$ module load matlab
-xena-01:~$ matlab
+easley051:~$ cd deepLearningExample/
+easley051:~$ module load matlab/R2024b
+easley051:~$ matlab
 ```
 
 This should bring up the MATLAB graphical user interface (GUI).
@@ -72,7 +72,7 @@ Use the file brower on the left side of the window to move into your 'deepLearni
 
 ### Get Required Example Functions <a name="1.2"></a>
 
-Before continuing, you must move the given MathWorks MATLAB functions (.m files) into yourly created 'deepLearningExample` directory. 
+Before continuing, you must move the given MathWorks MATLAB functions (.m files) into your newly created 'deepLearningExample` directory. 
 There are two ways to locate these files.
 
 1. Locate them interactively in MATLAB GUI.
@@ -87,7 +87,7 @@ Follow these steps to locate the files from with the MATLAB GUI opened in the ab
 >> downloadIAPRTC12Data('','')
 ```
 2. That will cause an error and provide links to the examples MATLAB thinks you are using. Click on the `JPEG Image Deblocking Using Deep Learning` link.
-3. This will move MATLAB's current wortking directory to that of the Example code.
+3. This will move MATLAB's current working directory to that of the Example code.
 4. In the file browser on the left side of the window, select all of the files in the current directory.
 5. Right click the selected files and hit 'copy'.
 6. Use the file brower on the left side to navigate back to your 'deepLearningExample' directory.
@@ -99,19 +99,19 @@ Follow these steps to copy the required example code into your new directory.
 
 1. Ssh into the compute node assigned to you (make sure the MATLAB module is loaded).
 ```bash
-xena:~$ ssh xena-01
+easley:~$ ssh easley051
 ```
 2. Move into the MATLAB Examples directory.
 ```bash
-xena-01:~$ cd /tmp/Examples/R2021a/deeplearning_shared/JPEGImageDeblockingDeepLearningExample
+easley051:~$ cd /tmp/Examples/R2024b/deeplearning_shared/JPEGImageDeblockingDeepLearningExample
 ```
 3. Copy all the needed files.
 ```bash
-xena-01:~$ cp *.m ~/deepLearningExample
+easley051:~$ cp *.m ~/deepLearningExample
 ```
 4. (Optional) Copy the pretrained example CNN.
 ```bash
-xena-01:~$ cp pretrianedJPEGDnCNN.mat ~/deepLearningExample
+easley051:~$ cp pretrainedJPEGDnCNN.mat ~/deepLearningExample
 ```
 
 
@@ -245,21 +245,21 @@ However, this uses massive amounts of RAM and should not be run for more than 3 
 You can use the plotting as verification that a model is actually training, but you should not attempt to fully train a model with the plotting enabled.
 
 Downloading and compressing the images can take quite a few minutes.
-Training the model takes up to 9 hours to complete 10 epochs on the dual GPU machines.
+Training the model takes up to 9 hours to complete 10 epochs on a dual GPU machine.
 Due to the way MATLAB trains a network with this depth (20 convolutional layers by default), these machines run out memory when training the network past 12 epochs with the rest of the settings left unchanged.
-One way to reduce memory usage and training time is top use fewer compressed images in the training set.
+One way to reduce memory usage and training time is to use fewer compressed images in the training set.
 Another option is to use a different layer setup with fewer hidden layers.
 
 ## Train CNN via Scheduled Job <a name="2"></a>
 
 Since training this CNN can take many hours, it is a good idea to take advantage of the Slurm scheduler.
 Interactive jobs can be stopped and interrupted due to internet connection issues.
-In the options of the CNN itself we set `Verbose=true`, which will allow us to see the status of the model being trained in an ouput file that is updated in real time.
+In the options of the CNN itself we set `Verbose=true`, which will allow us to see the status of the model being trained in an output file that is updated in real time.
 
 
 ### Slurm Scripts <a name="2.1"></a>
 
-It is reccomended that you use the dual GPU machines.
+It is recommended that you use both GPUs on an `h100` node.
 When using either of the scripts below, ensure the `ExecutionEnvironment` option in the above MATLAB script matches your choice of machine.
 
 #### Single GPU <a name="2.1.1"></a>
@@ -270,27 +270,27 @@ To request a job with a single GPU, create the following script with the name 'd
 #!/bin/bash
 
 #SBATCH --job-name DnCNN_singleGPU
-#SBATCH --mail-user jmccullough12@unm.edu
+#SBATCH --mail-user <YOUR EMAIL>
 #SBATCH --mail-type ALL
 #SBATCH --output dncnn_single_gpu.out
 #SBATCH --error dncnn_single_gpu.err
 #SBATCH --time 48:00:00
-#SBATCH --partition singleGPU
+#SBATCH --partition h100
 #SBATCH --ntasks 1
 #SBATCH --mem 0
 #SBATCH --cpus-per-task 16
-#SBATCH -G 1
+#SBATCH --gres=gpu:h100:1
 
 cd ~/deepLearningExample
 
-module load matlab
+module load matlab/R2024b
 matlab -nodisplay -r deep_learning_example > dncnn_single_training.out
 
 ```
 
 #### Dual GPU <a name="2.1.2"></a>
 
-To request a job with dual GPUs, create the following script with the name 'dncnn_dual_gpu.sh':
+To request a job with both GPUs on a node, create the following script with the name 'dncnn_dual_gpu.sh':
 
 ```bash
 #!/bin/bash
@@ -301,15 +301,15 @@ To request a job with dual GPUs, create the following script with the name 'dncn
 #SBATCH --output dncnn_dual_gpu.out
 #SBATCH --error dncnn_dual_gpu.err
 #SBATCH --time 48:00:00
-#SBATCH --partition dualGPU
+#SBATCH --partition h100
 #SBATCH --ntasks 1
 #SBATCH --mem 0
 #SBATCH --cpus-per-task 16
-#SBATCH -G 2
+#SBATCH --gres=gpu:h100:2
 
 cd ~/deepLearningExample
 
-module load matlab
+module load matlab/R2024b
 matlab -nodisplay -r deep_learning_example > dncnn_dual_training.out
 ```
 
@@ -317,12 +317,12 @@ matlab -nodisplay -r deep_learning_example > dncnn_dual_training.out
 
 To submit a job request using the single GPU script, use the following command:
 ```bash
-xena:~$ sbatch dncnn_single_gpu.sh
+easley:~$ sbatch dncnn_single_gpu.sh
 ```
 
 To submit a job request using the dual GPU script, use the following command:
 ```bash
-xena:~$ sbatch dncnn_dual_gpu.sh
+easley:~$ sbatch dncnn_dual_gpu.sh
 ```
 
 ### View Results <a name="2.3"></a>
@@ -331,12 +331,12 @@ While a network is being trained, you can see the results in real time with the 
 
 If you used the single GPU slurm script, use this command to view the output:
 ```bash
-xena:~$ cat ~/deepLearningExamples/dncnn_single_training.out
+easley:~$ cat ~/deepLearningExample/dncnn_single_training.out
 ```
 
 If you used the dual GPU slurm script, use this command to view the output:
 ```bash
-xena:~$ cat ~/deepLearningExamples/dncnn_dual_training.out
+easley:~$ cat ~/deepLearningExample/dncnn_dual_training.out
 ```
 
 ## Test the Model <a name="3"></a>
@@ -346,11 +346,11 @@ You can also use the pretrained example model (see the above instructions to get
 
 ### MATLAB Script <a name="3.1"></a>
 
-Use the following MATLAB Script to the results of a trianed model.
+Use the following MATLAB Script to the results of a trained model.
 To specify which model to use, replace the `<MODEL FILE>` with the name of your model.
 
-If the script is run interactively with X11 fowarding (see above instructions), an image will appear that shows the predictions made on a test image,.
-The resulting comparisons are also saved to an imaged titled 'results.tif' which can be viewed with your preferred image viewer.
+If the script is run interactively with X11 forwarding (see above instructions), an image will appear that shows the predictions made on a test image.
+The resulting comparisons are also saved to an image titled 'results.tif' which can be viewed with your preferred image viewer.
 
 Create the following script with the name 'test_model.m' and ensure it lives in the 'deepLearningExample' directory.
 ```bash
@@ -413,7 +413,7 @@ title("Compressed Images (above) Compared to Deblocked Images (below) with Quali
 imwrite(getframe(gca).cdata,'results.tif','tif');
 
 % Change the following boolean to look closer at a specific region of
-% interes in the test image
+% interest in the test image
 
 doROI = false;
 

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Quickbytes are tutorials designed to help CARC users.
          * [Parallel MATLAB Server](https://github.com/UNM-CARC/QuickBytes/blob/master/ParallelMatlabServer.md)
          * [Parallel MATLAB batch submission](https://github.com/UNM-CARC/QuickBytes/blob/parallel_matlab_profile_creation/Parallel%20MATLAB%20profile%20setup%20and%20batch%20submission.md)
          * [Using GPUs with MATLAB](https://github.com/UNM-CARC/QuickBytes/blob/master/Using%20GPUs%20on%20Xena%20with%20MATLAB.md)
-         * [MATLAB Deep Learning on Xena](https://github.com/UNM-CARC/QuickBytes/blob/master/MATLAB%20Deep%20Learning%20on%20Xena.md)
+         * [MATLAB Deep Learning on Easley](https://github.com/UNM-CARC/QuickBytes/blob/master/MATLAB%20Deep%20Learning%20on%20Easley.md)
       * JupyterHub
          * [JupyterHub: Parallel Processing with MPI](https://github.com/UNM-CARC/QuickBytes/blob/master/parallelization_with%20Jupyterhub_using_mpi.md)
          * [Conda python environments for JupyterHub](https://github.com/UNM-CARC/QuickBytes/blob/master/Conda_JupyterHub.md)


### PR DESCRIPTION
full xena -> easley rewrite. old file used the retired singleGPU/dualGPU partitions with -G flags, swapped for h100 with --gres=gpu:h100:1/2 (h100 nodes have 2 GPUs each so "dual GPU" maps cleanly to requesting both). bumped module load matlab -> matlab/R2024b.

tested for real: srun with the new partition/gres syntax actually allocates a GPU node, and gpuDevice() correctly detects the hardware (confirmed on an L40S: CUDADevice properties came back correct, compute capability 8.9, etc).

found and fixed a real bug: the "View Results" section referenced ~/deepLearningExamples/ (plural) but every other step in the doc creates/uses ~/deepLearningExample/ (singular) - that path never existed, would've been a "no such file" error.

also fixed a hardcoded personal email in the single-GPU sbatch script (was jmccullough12@unm.edu, swapped for the <YOUR EMAIL> placeholder the dual-GPU script already used) and a pile of typos: fowarding->forwarding (x3), reccommended/reccomended->recommended, wortking->working, yourly->your newly, pretrianed->pretrained, trianed->trained, top use->to use, an ouput->an output, an imaged titled->an image titled, interes->interest.

one thing I couldn't fully verify: the "locate example files" step relies on MATLAB's openExample()/GUI-driven example fetching, which only works in an interactive X11 session, not headless batch mode - I confirmed this limitation directly (openExample() throws "not supported in this configuration" under -batch). Left that part's file path close to the original structure (just bumped the version folder name) since I couldn't safely verify a different path without being able to trigger the actual interactive download.