### PR TITLE
Resource_usage.md

### DIFF
--- a/Resource_usage.md
+++ b/Resource_usage.md
@@ -1,49 +1,33 @@
 # Storage Policy
 
-Home directories are limited to 200 GB of storage. Project space is limited to 250 GB of storage. Scratch storage is limited to 1 TB (2 TB on Xena). Center-wide project scratch space is limited to 3 TB. To purchase additional storage please see our [pricing spreadsheet](https://carc.unm.edu/research/premium-research-computing-services.html).
+Home directories are limited to 100 GB soft / 200 GB hard quota. Scratch storage (`/easley/scratch` on Easley) has no personal per-user quota enforced. To purchase additional storage please see our [pricing spreadsheet](https://carc.unm.edu/research/premium-research-computing-services.html).
 
 # Resource Usage Policy
 
-Soft limits and hard limits are used to provide fair scheduling without wasting resources. The job scheduler will schedule all jobs meeting the soft limit requirements. If there are additional resources after all jobs meeting the soft limits are scheduled, then jobs meeting the hard limits are scheduled. The hard limits prevent users from monopolising the cluster for long periods by starting large jobs during temporary lulls in utilisation. 
+Slurm schedules jobs against per-user resource limits set on each partition's QOS (Quality of Service). These limits cap how much CPU, memory, and GPU a single user can have allocated at once on a given partition, so no one user can monopolize a partition and starve everyone else's jobs.
 
-## Xena Configuration
+## Easley Configuration
 
-Parameters |	Soft Limit  |	Hardlimit
---- | --- | ---
-Number of Processors |	64 |	128
-Number of Nodes	|4 (xena) <br> 2(BigMem) |  8 (xena) <br> 4 (Bigmem)
-Processors per Node |	16(xena) <br> 32(BigMem)  | 16 (xena) <br>  32 (BigMem)
+| Partition | Max CPUs/User | Max Memory/User | GPUs/User | Walltime |
+| --- | --- | --- | --- | --- |
+| general (default) | 512 | ~2 TB | - | 2-00:00:00 |
+| bigmem | 64 | ~2 TB | - | 2-00:00:00 |
+| h100 | 64 | ~1 TB | 2 | 2-00:00:00 |
+| l40s | 96 | ~168 GB | 3 | 2-00:00:00 |
+| interactive | 64 | ~250 GB | 1 (on GPU nodes) | 04:00:00 |
+| debug | 128 | ~500 GB | 2 (on GPU nodes) | 01:00:00 |
 
-
-Node Access Policy |	Single Job/Node ie (Multiple users can’t share resources across same node)
+Node Access Policy | Multiple users' jobs can share the same compute node, allocated by CPU/memory rather than whole nodes.
 --- | ---
 
+## Hopper Configuration
 
+| Partition | Max CPUs/User | Max Memory/User | Walltime |
+| --- | --- | --- | --- |
+| general (default) | 128 | ~380 GB | 2-00:00:00 |
+| debug | 8 | 25 GB | 2-00:00:00 |
 
-## Wheeler Configuration
-
-
-|                Queue: |   Default  |   Default  |    Debug   |   Debug    |
-|----------------------:|:----------:|:----------:|:----------:|:----------:|
-|             parameter | soft limit | hard limit | soft limit | hard limit |
-| Number of Processors  |     160    |     400    |     32     |     32     |
-|      Number of Nodes  |     20     |     50     |      4     |      4     |
-|   Processors per Node |      8     |      8     |      8     |      8     |
-|              Walltime |  48:00:00  |  48:00:00  |  01:00:00  |  01:00:00  |
-
-Node Access Policy | Multi Job/Node ie (Multiple users may share resources across same node)
+Node Access Policy | Multiple users' jobs can share the same compute node, allocated by CPU/memory rather than whole nodes.
 --- | ---
 
-
-
-## Gibbs Configuration
-
-Parameters |	Soft Limit  |	Hardlimit
---- | --- | ---
-Number of Processors |	96 |	96
-Number of Nodes	|6 | 6
-Processors per Node |	16  | 16
-Walltime |  72:00:00  | 72:00:00
-
-Node Access Policy |	Single Job/Node ie (Multiple users can’t share resources across same node)
---- | ---
+*This quickbyte was validated on 7/30/2026*

--- a/Resource_usage.md
+++ b/Resource_usage.md
@@ -25,7 +25,7 @@ Node Access Policy | Multiple users' jobs can share the same compute node, alloc
 | Partition | Max CPUs/User | Max Memory/User | Walltime |
 | --- | --- | --- | --- |
 | general (default) | 128 | ~380 GB | 2-00:00:00 |
-| debug | 8 | 25 GB | 2-00:00:00 |
+| debug | 8 | 25 GB | 04:00:00 |
 
 Node Access Policy | Multiple users' jobs can share the same compute node, allocated by CPU/memory rather than whole nodes.
 --- | ---


### PR DESCRIPTION
this whole doc was 100% dead clusters - xena, wheeler, gibbs, none of which exist anymore. rewrote with real current numbers for easley and hopper, pulled straight from sacctmgr (per-user QOS limits) and sinfo (partition walltimes/specs) on both clusters. also fixed the storage policy blurb - checked actual quota on easley, home dir is 100GB soft/200GB hard (not the old "200GB" flat number), and scratch has no personal quota enforced at all (confirmed with the quota command).

heads up: the soft/hard limit framing from the old PBS/Torque docs doesn't map cleanly onto how Slurm's QOS system actually works, so I presented these as "max per-user" limits per partition instead of forcing a soft/hard distinction that doesn't really exist anymore. if there's an official CARC policy doc elsewhere with different numbers, worth cross-checking against that, but everything here reflects what's actually configured on the clusters right now.