### PR TITLE
slurm_accounting.md

### DIFF
--- a/slurm_accounting.md
+++ b/slurm_accounting.md
@@ -19,10 +19,10 @@ Example:
 ```bash
 [yourUsername@easley ~]$ myaccounts
 ```
-```bash
-User            Account
-yourUsername    systems
-yourUsername    yourIdNumber
+```
+   Account      Description            PI 
+---------- -------------------- ---------- 
+yourIdNumber       yourIdNumber   yourIdNumber
 ```
 
 The account name corresponds to the project ID.
@@ -128,4 +128,4 @@ sacctmgr show account yourIdNumber
 
 ---
 
-*This QuickByte was validated on June 22, 2026.*
+*This QuickByte was validated on July 30, 2026.*


### PR DESCRIPTION
tested every command for real - myaccounts, sacctmgr show account, sacctmgr show user, srun --account, and the ~/.default_slurm_account file mechanic. all work.

found one real bug: the doc's example output for myaccounts shows columns "User | Account", but the actual command outputs "Account | Description | PI" - no User column at all. fixed the example to match real output.