### PR TITLE
logging_in.md

### DIFF
--- a/logging_in.md
+++ b/logging_in.md
@@ -21,4 +21,4 @@ Where `CARC-USERNAME` is the username you were assigned once your account was ap
 If you are unsure of your current password, please reference [the password reset quickbyte.](password_reset.md)
 
 
-*This quickbyte was validated on 5/21/2024*
+*This quickbyte was validated on 8/3/2026*


### PR DESCRIPTION
doc already had easley/hopper as the example machine names, no stale wheeler/xena/taos refs. tested ssh <user>@<machine>.alliance.unm.edu login pattern for real against both easley and hopper, works as documented. validation date was stale (5/21/2024), updated to today.