### PR TITLE
transfer_data.md

### DIFF
--- a/transfer_data.md
+++ b/transfer_data.md
@@ -2,7 +2,7 @@
 
 ### Where is your data?
 
-Your home directory, `/users/your-user-name/`, is shared across all CARC machines, meaning that once your data has been uploaded to your home directory, it is accessible regardless of which machine you are logged in to. Refer to our [CARC Systems documentation page](#) for details on CARC systems.
+Your home directory, `/users/your-user-name/`, is shared across all CARC machines, meaning that once your data has been uploaded to your home directory, it is accessible regardless of which machine you are logged in to.
 
 ### Graphical User Interface (GUI) options
 


### PR DESCRIPTION
ran the documented scp and rsync commands for real against easley, both directions (upload and download), with a throwaway test file - all four worked verbatim as written in the doc. checked the GUI tool links (filezilla/winscp/fetch/cyberduck), all resolve. also removes bbcp section (bbcp isn't usable on these systems) and fixes a dead '(#)' placeholder link that pointed nowhere, plus a walltime mismatch between the PBS and Slurm examples in pbs2slurm.md that was caught along the way.