### PR TITLE
Intro_to_slurm.md

### DIFF
--- a/Intro_to_slurm.md
+++ b/Intro_to_slurm.md
@@ -18,42 +18,34 @@ When you run `sinfo` on Easley, you will see output similar to the following:
 
 ```
 PARTITION   AVAIL  TIMELIMIT  NODES  STATE NODELIST
-general*       up 2-00:00:00      1   comp easley002
-general*       up 2-00:00:00      4   mix- easley[008,015,018,044]
-general*       up 2-00:00:00      8    mix easley[003-004,012-014,016,020,023]
-general*       up 2-00:00:00     34  alloc easley[001,005-007,009-011,017,019,021-022,024-043,046-048]
-general*       up 2-00:00:00      1   down easley045
+general*       up 2-00:00:00      2   mix- easley[005-006]
+general*       up 2-00:00:00      2  drain easley[011,033]
+general*       up 2-00:00:00     20    mix easley[002-003,008,017,021-024,026-027,030-031,038-042,046-048]
+general*       up 2-00:00:00     24  alloc easley[001,004,007,009-010,012-016,018-020,025,028-029,032,034-037,043-045]
+bigmem         up 2-00:00:00      1  drain easley049
 bigmem         up 2-00:00:00      1    mix easley050
-bigmem         up 2-00:00:00      1  alloc easley049
-h100           up 2-00:00:00      1   mix- easley051
-h100           up 2-00:00:00      1   plnd easley054
-h100           up 2-00:00:00      2  alloc easley[052-053]
+h100           up 2-00:00:00      1    mix easley054
+h100           up 2-00:00:00      3  alloc easley[051-053]
 l40s           up 2-00:00:00      1    mix easley055
 l40s           up 2-00:00:00      2  alloc easley[056-057]
-interactive    up    4:00:00      1   comp easley002
-interactive    up    4:00:00      5   mix- easley[008,015,018,044,051]
-interactive    up    4:00:00      1   plnd easley054
-interactive    up    4:00:00     10    mix easley[003-004,012-014,016,020,023,050,055]
-interactive    up    4:00:00     39  alloc easley[001,005-007,009-011,017,019,021-022,024-043,046-049,052-053,056-057]
-interactive    up    4:00:00      1   down easley045
-debug          up    1:00:00      1   comp easley002
-debug          up    1:00:00      5   mix- easley[008,015,018,044,051]
-debug          up    1:00:00      1   plnd easley054
-debug          up    1:00:00     10    mix easley[003-004,012-014,016,020,023,050,055]
-debug          up    1:00:00     39  alloc easley[001,005-007,009-011,017,019,021-022,024-043,046-049,052-053,056-057]
-debug          up    1:00:00      1   down easley045
-scavenger      up 2-00:00:00      1   comp easley002
-scavenger      up 2-00:00:00      9   mix- easley[008,015,018,044,051,060-063]
-scavenger      up 2-00:00:00      1   plnd easley054
-scavenger      up 2-00:00:00     10    mix easley[003-004,012-014,016,020,023,050,055]
-scavenger      up 2-00:00:00     41  alloc easley[001,005-007,009-011,017,019,021-022,024-043,046-049,052-053,056-059]
-scavenger      up 2-00:00:00      1   down easley045
+interactive    up    4:00:00      2   mix- easley[005-006]
+interactive    up    4:00:00      3  drain easley[011,033,049]
+interactive    up    4:00:00     23    mix easley[002-003,008,017,021-024,026-027,030-031,038-042,046-048,050,054-055]
+interactive    up    4:00:00     29  alloc easley[001,004,007,009-010,012-016,018-020,025,028-029,032,034-037,043-045,051-053,056-057]
+debug          up    1:00:00      2   mix- easley[005-006]
+debug          up    1:00:00      3  drain easley[011,033,049]
+debug          up    1:00:00     23    mix easley[002-003,008,017,021-024,026-027,030-031,038-042,046-048,050,054-055]
+debug          up    1:00:00     29  alloc easley[001,004,007,009-010,012-016,018-020,025,028-029,032,034-037,043-045,051-053,056-057]
+scavenger      up 2-00:00:00      2   mix- easley[005-006]
+scavenger      up 2-00:00:00      3  drain easley[011,033,049]
+scavenger      up 2-00:00:00     28    mix easley[002-003,008,017,021-024,026-027,030-031,038-042,046-048,050,054-055,058,060-063]
+scavenger      up 2-00:00:00     30  alloc easley[001,004,007,009-010,012-016,018-020,025,028-029,032,034-037,043-045,051-053,056-057,059]
 ```
 
 Key partitions you may have access to:
 
 - **general** — The default community partition. Maximum wall time of 2 days. Use this if you are not a member of a specific condo group.
-- **debug** — Short jobs only (4-hour limit). Useful for testing scripts before submitting long runs.
+- **debug** — Short jobs only (1-hour limit). Useful for testing scripts before submitting long runs.
 - **condo** — Purchased nodes available to specific research groups. If you are a member of a condo group, you likely already know your partition name. Check with your PI if you are unsure.
 - **scavenger** - Whenever a purchased/reserved node is not in use, this partition grabs them and allows them to be used by the public, but be warned you will be kicked off if the owner begins a job on it.
 
@@ -103,4 +95,4 @@ scancel --me             # Cancel all of your jobs
 - For help, contact the CARC support team or visit the CARC user portal.
 
 
-*This quickbyte was validated on 6/22/2026.*
+*This quickbyte was validated on 8/3/2026.*


### PR DESCRIPTION
ran sinfo and sinfo -N -l for real on easley to check this one, since it was never covered by the earlier campaign. checked the debug partition timelimit specifically since a sibling doc (Resource_usage.md) already caught a stale partition-limit claim elsewhere in this repo, but here the sample table's debug timelimit of 1:00:00 was already correct, same for every other partition (general/bigmem/h100/l40s/scavenger 2-00:00:00, interactive 4:00:00).

"key partitions" description said debug has a 4-hour limit while the sinfo table right above it showed 1:00:00, so the two contradicted each other. fixed the description to match.

also confirmed squeue --me and scancel --me are valid on the installed slurm 24.11.