### PR TITLE
pbs2slurm.md

### DIFF
--- a/pbs2slurm.md
+++ b/pbs2slurm.md
@@ -13,7 +13,7 @@ To submit jobs on Slurm-based systems, you must submit a Slurm job script. If yo
 
 Additional references:
 
-* PBS job submission: http://carc.unm.edu/user-support-2/using-carc-systems1/running-jobs/submitting-jobs.html
+* PBS job submission: https://carc.unm.edu/user-support-2/running-jobs/submitting-jobs.html
 * Slurm QuickBytes: https://github.com/UNM-CARC/QuickBytes/blob/master/Intro_to_slurm.md
 
 ---
@@ -127,7 +127,7 @@ The equivalent Slurm script is:
 
 #SBATCH --nodes=1
 #SBATCH --ntasks-per-node=1
-#SBATCH --time=00:05:00
+#SBATCH --time=01:00:00
 #SBATCH --job-name=test
 #SBATCH --output=test.out
 #SBATCH --error=test.err
@@ -145,4 +145,4 @@ Submit the job with:
 sbatch job_script.slurm
 ```
 
-*This quickbyte was validated on 6/25/2026*
+*This quickbyte was validated on 8/3/2026*


### PR DESCRIPTION
the pbs walltime=01:00:00 vs slurm --time=00:05:00 mismatch from an earlier pass was already fixed on this branch, verified it's still correct (both scripts say 01:00:00 now).

found a dead link: the carc pbs job-submission link 404s (http://carc.unm.edu/user-support-2/using-carc-systems1/running-jobs/submitting-jobs.html). Replaced with link to current page at https://carc.unm.edu/user-support-2/running-jobs/submitting-jobs.html

also submitted the example job_script.slurm end-to-end on easley with a real test.py (job 1037947), completed successfully with the expected output. the pbs/slurm conversion tables checked out against man pages and slurm docs.