### PR TITLE
Add new-user onboarding quickbytes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,10 @@
 # QuickBytes
 Quickbytes are tutorials designed to help CARC users.  
     
+   * Getting Started at CARC
+      * [Welcome to CARC](https://github.com/UNM-CARC/QuickBytes/blob/master/welcome_to_carc.md)
+      * [Getting Access: Accounts and Projects](https://github.com/UNM-CARC/QuickBytes/blob/master/getting_access.md)
+
    * [Linux-Intro](https://github.com/UNM-CARC/QuickBytes/blob/master/linux_intro.md)
 
    * Running jobs

--- a/getting_access.md
+++ b/getting_access.md
@@ -1,0 +1,49 @@
+# Getting Access: Accounts and Projects
+
+This covers the two things you need before you can log in anywhere: a personal account, and a project to work under. If you haven't read **Welcome to CARC** yet, start there first for context on what CARC is.
+
+## Two systems, two different jobs
+
+CARC access runs through two separate websites that each do one thing:
+
+- **Mokey** (mokey.alliance.unm.edu) — your personal account. Username, password, SSH keys, two-factor authentication. See the **CARC Cluster Allocation and Accounting Services** quickbyte for a walkthrough of Mokey's account features (password resets, 2FA, SSH keys) if you need to manage those later.
+- **ColdFront** (coldfront.alliance.unm.edu) — projects. A project is your research group's space on CARC: it's tied to a PI (usually your advisor or the faculty member running the lab), and it's where compute/storage resources actually get requested and assigned.
+
+Having a Mokey account by itself doesn't give you access to anything — you also need to be added to a project in ColdFront. Both steps matter.
+
+## If you're a student or new lab member joining an existing group
+
+Most established labs already have a CARC project. In that case:
+
+1. **Create your account** at mokey.alliance.unm.edu, if you don't already have one. This works directly if you have a UNM affiliation (student, staff, faculty).
+2. **Ask your PI to add you to their project** through ColdFront. Adding people to a project is the PI's job, not something you can do yourself — so this step means literally asking them, or whoever manages the lab's CARC access.
+3. Once you've been added, you're ready to log in — see **Logging in**.
+
+If you're **not** UNM-affiliated (an external collaborator), you can't self-register through Mokey. Instead, ask your UNM PI to submit an account request on your behalf.
+
+## If you're a PI and need to create a new project
+
+1. **Check eligibility.** PI status at CARC follows the same criteria as being a UNM Grant PI, as determined by the Office of the Vice President for Research. If you're already a funded PI at UNM, you qualify.
+2. **Log into ColdFront** (coldfront.alliance.unm.edu) and create a new project there.
+3. **Request resources for the project.** Compute and storage aren't automatic — you request what your project needs through ColdFront, and CARC assigns it.
+4. **Add your students and collaborators** to the project in ColdFront, once each of them has their own Mokey account.
+
+If anything in the ColdFront interface itself is unclear once you're in there, that's a good office-hours or help-ticket question — the process above covers what needs to happen, not a click-by-click tour of the site.
+
+## Quick summary
+
+| You are... | What you need |
+|---|---|
+| A student/collaborator with a PI who already has a project | A Mokey account, then ask your PI to add you in ColdFront |
+| A non-UNM collaborator | Your UNM PI submits an account request for you |
+| A PI starting a new project | Confirm eligibility, then create the project and request resources in ColdFront |
+
+## Where to go next
+
+Once you have both a Mokey account and you've been added to a project:
+
+- **Logging in** covers connecting to the cluster for the first time.
+- **Slurm on CARC Easley** covers the basics of partitions and checking what's available.
+- **Example Slurm Scripts** walks through submitting your first job, hello-world and up.
+
+*This quickbyte was validated on 8/11/2026*

--- a/welcome_to_carc.md
+++ b/welcome_to_carc.md
@@ -1,0 +1,40 @@
+# Welcome to CARC
+
+This is the starting point if you're brand new to CARC and have never used anything like this before. No coding background needed to read this one.
+
+## What CARC is
+
+CARC (Center for Advanced Research Computing) is a UNM department that runs shared, powerful computers for research, and helps people use them. If your research needs more computing power or storage than a laptop can give you, CARC is where that comes from.
+
+Using CARC is free for UNM faculty, staff, and student researchers. Non-UNM collaborators can also get access if a UNM faculty member (their "PI") sponsors them.
+
+## What "the cluster" actually is
+
+A cluster is a large group of computers (called nodes) connected together, that many researchers share at the same time. Instead of just running a program the moment you hit enter like you would on your own laptop, you ask for a slice of the cluster's time and resources, wait briefly for it to become available, and then your program runs on it. That waiting/scheduling is handled automatically by software called Slurm — you don't do anything special to trigger it, it's just how shared systems like this work.
+
+CARC runs two clusters: **Easley** (general-purpose, what most people use) and **Hopper**. You'll usually be told which one applies to you, and if not, Easley is the default assumption.
+
+## What CARC can help with
+
+- Access to the clusters themselves, plus storage space for your data
+- One-on-one help figuring out how to actually run your specific research code
+- Workshops and training sessions for people new to this kind of computing
+- Written tutorials (like this one — we call them "QuickBytes") covering specific tools and tasks
+- General troubleshooting when something isn't working
+
+You are not expected to already know how any of this works. Asking questions is exactly what CARC is for.
+
+## How to get help from a real person
+
+- **Open office hours** — Tuesdays and Thursdays, 11:00am-12:00pm MT, over Zoom, first-come-first-served: https://unm.zoom.us/j/4232179831
+- **Consultation hours** — for a longer, scheduled one-on-one conversation, email Matthew Fricke at mfricke@unm.edu to book a time
+- **Help ticket** — for anything else, or if you can't make it to office hours: https://support.alliance.unm.edu/
+
+If you're joining a Zoom office hours session, use a computer rather than a phone — CARC staff will likely want you to share your screen so they can see what you're seeing.
+
+## Where to go next
+
+- If you don't have an account yet, or aren't sure how your research group's access works: see **Getting Access: Accounts and Projects**
+- If you already have access: that same quickbyte points you to logging in and running your first job from there
+
+*This quickbyte was validated on 8/11/2026*


### PR DESCRIPTION
two new quickbytes aimed at someone who's never coded and never used a cluster before, meant to be the answer when someone asks "I'm a new grad student, how do I start?" or "how do I create a project?"

welcome_to_carc.md - who carc is, what a cluster means in plain terms, what carc can help with, how to reach a person for help. sourced from carc.unm.edu's own mission/support pages.

getting_access.md - the mokey (account) + coldfront (project) flow, split into "joining an existing pi's project" and "pi creating a new project". sourced from carc.unm.edu's published getting-started page, since i can't personally test the coldfront pi/admin flow without an account of that type.

neither doc re-explains anything that already has its own quickbyte, they link out to logging_in.md, Intro_to_slurm.md, and submitting_sbatch_jobs.md instead of repeating that content. an earlier draft also had a "first day on the cluster" doc that mostly just re-explained those existing docs at a more basic level, dropped it and folded the couple of relevant bits into getting_access.md instead.

added both to the readme under a new "getting started at carc" section at the top.